### PR TITLE
Surface the real cause of auth 500s (DB state in health check, real error messages in UI)

### DIFF
--- a/backend/src/__tests__/routes/auth.test.ts
+++ b/backend/src/__tests__/routes/auth.test.ts
@@ -158,6 +158,7 @@ describe('Auth Routes', () => {
       const res = await request(app).get('/api/v1/test');
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
+      expect(res.body.database).toBe('connected');
     });
   });
 });

--- a/backend/src/middleware/error.ts
+++ b/backend/src/middleware/error.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
 import ErrorResponse from '../utils/errorResponse';
 
 /**
@@ -40,6 +41,16 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
 
   if (err.name === 'TokenExpiredError') {
     error = new ErrorResponse('Token expired. Please log in again.', 401);
+  }
+
+  // An unexplained 500 while Mongo is unreachable is a database outage
+  // (e.g. mongoose buffering timeouts), not a generic server error. Say so,
+  // so the frontend and logs point straight at the real problem.
+  if (!error.statusCode && mongoose.connection.readyState !== 1) {
+    error = new ErrorResponse(
+      'Database unavailable: the server cannot reach MongoDB. Admin: check that the Atlas cluster is running and MONGO_URI on Render is current.',
+      503
+    );
   }
 
   // Send the error response

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import mongoSanitize from 'express-mongo-sanitize';
 import rateLimit from 'express-rate-limit';
 import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
+import mongoose from 'mongoose';
 import { connectDB } from './config/db';
 import errorHandler from './middleware/error';
 
@@ -81,15 +82,23 @@ const limiter = rateLimit({
 });
 app.use(limiter);
 
-// Add a test endpoint
-app.get('/api/test', (req, res) => {
-  res.json({ success: true, message: 'API is running' });
-});
+// Health check used by the frontend and for production diagnosis: reports
+// whether the DB is reachable and whether required env vars are present
+// (booleans only - never the values).
+const healthCheck = (req: express.Request, res: express.Response) => {
+  res.json({
+    success: true,
+    message: 'API is running',
+    database: mongoose.connection.readyState === 1 ? 'connected' : 'disconnected',
+    mongoUriConfigured: Boolean(process.env.MONGO_URI),
+    jwtSecretConfigured: Boolean(process.env.JWT_SECRET)
+  });
+};
 
-// Add a test endpoint for /api/v1/test to match frontend health check
-app.get('/api/v1/test', (req, res) => {
-  res.json({ success: true, message: 'API is running' });
-});
+app.get('/api/test', healthCheck);
+
+// Same health check on /api/v1/test to match frontend health check
+app.get('/api/v1/test', healthCheck);
 
 // Mount routers
 app.use('/api/v1/auth', authRoutes);

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -41,23 +41,31 @@ export const handleApiError = (
   // Response with error status
   else if (error.response) {
     const { status } = error.response;
-    
+    // The backend sends { success: false, error: '...' }; prefer its message
+    // over generic fallbacks so users see the real reason (e.g. 'Invalid
+    // credentials', 'Database unavailable: ...').
+    const serverMessage = error.response.data?.error || error.response.data?.message;
+
     // Authentication errors
     if (status === 401 || status === 403) {
-      message = status === 401 
-        ? 'Your session has expired. Please log in again.' 
-        : 'You do not have permission to access this resource.';
+      message = serverMessage || (status === 401
+        ? 'Your session has expired. Please log in again.'
+        : 'You do not have permission to access this resource.');
       type = ErrorType.AUTHENTICATION;
     }
     // Validation errors
     else if (status === 400 || status === 422) {
-      message = error.response.data?.message || 'Please check your input and try again.';
+      message = serverMessage || 'Please check your input and try again.';
       type = ErrorType.VALIDATION;
     }
     // Server errors
     else if (status >= 500) {
-      message = 'Server error. Please try again later.';
+      message = serverMessage || 'Server error. Please try again later.';
       type = ErrorType.SERVER;
+    }
+    // Anything else (404s, rate limits, ...)
+    else if (serverMessage) {
+      message = serverMessage;
     }
   }
   // Use error message if available


### PR DESCRIPTION
## Why
Login and register both return 500 in production. The two plausible causes — MongoDB still unreachable (mongoose buffering timeout) or `JWT_SECRET` unset on Render — are environment problems the app was hiding behind generic error messages.

## Changes
- **Self-diagnosing health check:** `GET /api/v1/test` now reports `database: connected|disconnected` plus `mongoUriConfigured` / `jwtSecretConfigured` booleans (never the values). Open it in a browser to see exactly what's wrong.
- **Clear DB-outage errors:** unexplained 500s while Mongo is disconnected become an explicit `503 Database unavailable: ...` message.
- **Frontend shows real errors:** `handleApiError` previously read the wrong field (`data.message`) for 400s and discarded the server's message entirely for 5xx — users only ever saw "Server error. Please try again later." It now prefers the backend's `{ error }` message for every status class, so the login/register forms display the actual reason (e.g. "Invalid credentials", "Database unavailable: ...").

## Verification
- Frontend: build passes, 14/14 tests pass locally.
- Backend: `tsc` passes locally; the DB-backed suite runs in CI (sandbox here can't download the mongod binary). Health-check test extended to assert the new `database` field.

https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G)_