### PR TITLE
Real study sessions, studied-state tracking, study-page layout fix, uniform cards (plan PR 2/3)

### DIFF
--- a/backend/src/__tests__/routes/auth.test.ts
+++ b/backend/src/__tests__/routes/auth.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { describe, it, expect, beforeEach } from 'vitest';
 import User from '../../models/User';
+import Note from '../../models/Note';
 import app from '../../server';
 
 // End-to-end smoke of the auth flow against the in-memory MongoDB from
@@ -144,12 +145,90 @@ describe('Auth Routes', () => {
         .send({ email: credentials.email, password: credentials.password });
 
       const res = await request(app)
-        .get('/api/v1/users/feed?type=ai_summary_generated,ai_flashcards_generated')
+        .get('/api/v1/users/feed?type=study,earn_badge')
         .set('Authorization', `Bearer ${token}`);
 
       expect(res.status).toBe(200);
-      // No AI activity yet - the filter should simply return an empty list
+      // No study/badge activity yet - the filter should simply return an empty list
       expect(res.body.data.activities).toEqual([]);
+    });
+  });
+
+  describe('POST /api/v1/users/study-complete', () => {
+    let token: string;
+    let noteId: string;
+
+    beforeEach(async () => {
+      const res = await request(app).post('/api/v1/auth/register').send(credentials);
+      token = res.body.token;
+      const note = await Note.create({
+        title: 'Logarithmic Functions',
+        fileUrl: 'https://example.com/note.pdf',
+        fileType: 'pdf',
+        fileSize: 1024,
+        subject: 'General Mathematics',
+        grade: '12',
+        semester: '1',
+        quarter: '2',
+        topic: 'Logarithms',
+        user: res.body.user._id ?? res.body.user.id
+      });
+      noteId = note._id.toString();
+    });
+
+    it('records the studied note, awards XP, and updates the streak', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/study-complete')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ noteId, duration: 300 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.studiedNote).toMatchObject({
+        noteId,
+        timesStudied: 1,
+        totalSeconds: 300
+      });
+      expect(res.body.data.xpEarned).toBeGreaterThan(0);
+      expect(res.body.data.user.streak.current).toBeGreaterThanOrEqual(1);
+
+      // The profile now carries the studied record for the notes grid
+      const me = await request(app)
+        .get('/api/v1/auth/me')
+        .set('Authorization', `Bearer ${token}`);
+      expect(me.body.data.studiedNotes).toHaveLength(1);
+      expect(me.body.data.studiedNotes[0].note.toString()).toBe(noteId);
+    });
+
+    it('accumulates time and count on repeat sessions for the same note', async () => {
+      await request(app)
+        .post('/api/v1/users/study-complete')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ noteId, duration: 300 });
+      const res = await request(app)
+        .post('/api/v1/users/study-complete')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ noteId, duration: 200 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.studiedNote).toMatchObject({
+        timesStudied: 2,
+        totalSeconds: 500
+      });
+    });
+
+    it('rejects an unknown note id with 404 and a missing duration with 400', async () => {
+      const missing = await request(app)
+        .post('/api/v1/users/study-complete')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ noteId: '64b5f9d2f1a2c34d56789012', duration: 60 });
+      expect(missing.status).toBe(404);
+
+      const badDuration = await request(app)
+        .post('/api/v1/users/study-complete')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ noteId });
+      expect(badDuration.status).toBe(400);
     });
   });
 

--- a/backend/src/controllers/UserActivityFeedController.ts
+++ b/backend/src/controllers/UserActivityFeedController.ts
@@ -4,7 +4,12 @@ import ErrorResponse from '../utils/errorResponse';
 import { CustomRequest } from '../middleware/auth';
 import UserService from '../services/UserService';
 import BadgeService from '../services/BadgeService';
-import { IUserActivity } from '../models/User';
+import mongoose from 'mongoose';
+import User, { IUserActivity } from '../models/User';
+import Note from '../models/Note';
+
+// XP awarded for completing a study session on a note
+const STUDY_COMPLETE_XP = 5;
 
 export default class UserActivityFeedController {
     /**
@@ -76,22 +81,64 @@ export default class UserActivityFeedController {
         }
 
         const { noteId, duration } = req.body;
-        if (!noteId || !duration) {
-            return next(new ErrorResponse('Note ID and duration are required', 400));
+        const durationSeconds = Number(duration);
+        if (!noteId || !Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+            return next(new ErrorResponse('Note ID and a positive duration (seconds) are required', 400));
+        }
+
+        const note = await Note.findById(noteId).select('title');
+        if (!note) {
+            return next(new ErrorResponse(`Note not found with id of ${noteId}`, 404));
         }
 
         try {
-            const user = await UserService.updateStudyStreak(req.user.id);
-            await BadgeService.checkAndAwardBadges(req.user.id, 'study_complete', { noteId, duration });
+            // Streak first: it loads, mutates, saves and returns a PLAIN
+            // object (toObject), so reload the document for further writes.
+            await UserService.updateStudyStreak(req.user.id);
+            const user = await User.findById(req.user.id);
+            if (!user) {
+                return next(new ErrorResponse('User not found', 404));
+            }
+
+            // Per-note studied record (upsert into the embedded array)
+            const existing = user.studiedNotes.find(sn => sn.note.toString() === noteId);
+            if (existing) {
+                existing.timesStudied += 1;
+                existing.totalSeconds += durationSeconds;
+                existing.lastStudiedAt = new Date();
+            } else {
+                user.studiedNotes.push({
+                    note: note._id as mongoose.Types.ObjectId,
+                    lastStudiedAt: new Date(),
+                    totalSeconds: durationSeconds,
+                    timesStudied: 1
+                });
+            }
+
+            user.addActivity('study', `Studied "${note.title}"`, STUDY_COMPLETE_XP);
+            await user.save();
+
+            const newBadges = await BadgeService.checkAndAwardBadges(req.user.id, 'study_complete', { noteId, duration: durationSeconds });
+            const studiedEntry = user.studiedNotes.find(sn => sn.note.toString() === noteId);
 
             res.status(200).json({
                 success: true,
                 data: {
                     message: 'Study session logged successfully',
+                    xpEarned: STUDY_COMPLETE_XP,
                     user: {
                         streak: user.streak,
+                        xp: user.xp,
+                        level: user.level,
                         lastActive: user.lastActive
-                    }
+                    },
+                    studiedNote: studiedEntry ? {
+                        noteId,
+                        timesStudied: studiedEntry.timesStudied,
+                        totalSeconds: studiedEntry.totalSeconds,
+                        lastStudiedAt: studiedEntry.lastStudiedAt
+                    } : null,
+                    newBadges: newBadges ?? []
                 }
             });
         } catch (error) {

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -25,6 +25,16 @@ export interface IUserSubject extends Document { // Sub-document or object type
   topics: string[];
 }
 
+// Per-note study record: which notes this user has studied, when, and for
+// how long in total. Powers the "Studied" marker on note cards and the
+// dashboard's studied count / continue-studying widgets.
+export interface IUserStudiedNote {
+  note: mongoose.Types.ObjectId;
+  lastStudiedAt: Date;
+  totalSeconds: number;
+  timesStudied: number;
+}
+
 // Main User Interface
 export interface IUser extends Document {
   name: string;
@@ -55,6 +65,7 @@ export interface IUser extends Document {
   emailVerificationTokenExpire?: Date; // Added field based on service logic
   emailVerified: boolean;
   favoriteNotes: mongoose.Types.ObjectId[];
+  studiedNotes: IUserStudiedNote[];
   createdAt: Date;
   updatedAt: Date;
 
@@ -169,6 +180,12 @@ const UserSchema = new Schema<IUser>(
     emailVerificationTokenExpire: Date, // Added field based on service logic
     emailVerified: { type: Boolean, default: false },
     favoriteNotes: [{ type: Schema.Types.ObjectId, ref: 'Note' }],
+    studiedNotes: [{
+      note: { type: Schema.Types.ObjectId, ref: 'Note', required: true },
+      lastStudiedAt: { type: Date, default: Date.now },
+      totalSeconds: { type: Number, default: 0 },
+      timesStudied: { type: Number, default: 0 }
+    }],
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
   },

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -161,9 +161,10 @@ export class AuthService {
       profileImage: user.profileImage,
       biography: user.biography,
       preferences: user.preferences,
-      badges: user.badges, 
+      badges: user.badges,
       activity: user.activity ? user.activity.slice(0, 10) : [], // Ensure activity is not null
       subjects: user.subjects,
+      studiedNotes: user.studiedNotes ?? [],
       createdAt: user.createdAt,
       emailVerified: user.emailVerified
       // Ensure any other fields returned are consistent with frontend UserProfile type

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -377,7 +377,13 @@ export default class UserService {
 
         // Update streak based on days difference
         if (diffDays === 0) {
-            // Same day usage, no streak change
+            // Same-day usage keeps the streak, but a fresh account starts
+            // with current=0 and lastUsed defaulted to today - being active
+            // today must still count as a 1-day streak.
+            if ((user.streak.current ?? 0) < 1) {
+                user.streak.current = 1;
+                user.streak.max = Math.max(user.streak.max ?? 0, 1);
+            }
         } else if (diffDays === 1) {
             // Used yesterday, increment streak
             user.streak.current = (user.streak.current ?? 0) + 1;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Toaster } from 'react-hot-toast';
 import toast from 'react-hot-toast';
@@ -35,6 +35,28 @@ import NetworkStatusMonitor from './components/ui/NetworkStatusMonitor';
 if (typeof window !== 'undefined') {
   (window as any).debug = debug;
 }
+
+// Standard chrome: padded, width-capped content column for regular pages.
+// The app shell is h-screen, so this main is the scroll container.
+const StandardLayout: React.FC = () => (
+  <main className="flex-grow min-h-0 overflow-y-auto">
+    <div className="p-4 md:p-6 max-w-7xl mx-auto w-full">
+      <ErrorBoundary>
+        <Outlet />
+      </ErrorBoundary>
+    </div>
+  </main>
+);
+
+// Full-bleed chrome for immersive views (the PDF study page): the page owns
+// the whole area below the header, with no padding or width cap
+const FullBleedLayout: React.FC = () => (
+  <main className="flex-grow w-full min-h-0 flex flex-col overflow-hidden">
+    <ErrorBoundary>
+      <Outlet />
+    </ErrorBoundary>
+  </main>
+);
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
@@ -177,39 +199,43 @@ function App() {
           <NetworkStatusMonitor />
           <OfflineDetector />
           <Sidebar />
-          <div className="flex flex-col min-h-screen md:ml-64">
+          <div className="flex flex-col h-screen md:ml-64">
             <Header toggleDarkMode={toggleDarkMode} />
-            <main className="flex-grow p-4 md:p-6 max-w-7xl mx-auto w-full">
-              <ErrorBoundary>
-                <Routes>
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/register" element={<Register />} />
+            <Routes>
+              <Route element={<StandardLayout />}>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
 
-                  {/* Protected routes - unauthenticated visitors are sent to /login */}
-                  <Route element={<PrivateRoute />}>
-                    <Route path="/" element={<HomePage />} />
-                    {/* Legacy alias: older code navigated to /dashboard */}
-                    <Route path="/dashboard" element={<Navigate to="/" replace />} />
-                    <Route path="/my-notes" element={<MyNotes />} />
-                    <Route path="/donate" element={<Donate />} />
-                    <Route path="/progress" element={<Progress />} />
-                    <Route path="/profile" element={<ProfilePage />} />
-                    <Route path="/settings" element={<Settings toggleDarkMode={toggleDarkMode} darkMode={darkMode} />} />
-                    <Route path="/badges" element={<Badges />} />
-                    <Route path="/view-note" element={<NoteViewer />} />
-                    <Route path="/view-note/:noteId" element={<NoteViewer />} />
-                    <Route path="/notes" element={<NoteFilterPage />} />
-                    <Route path="/notes/upload" element={<NoteUploader />} />
-                  </Route>
+                {/* Protected routes - unauthenticated visitors are sent to /login */}
+                <Route element={<PrivateRoute />}>
+                  <Route path="/" element={<HomePage />} />
+                  {/* Legacy alias: older code navigated to /dashboard */}
+                  <Route path="/dashboard" element={<Navigate to="/" replace />} />
+                  <Route path="/my-notes" element={<MyNotes />} />
+                  <Route path="/donate" element={<Donate />} />
+                  <Route path="/progress" element={<Progress />} />
+                  <Route path="/profile" element={<ProfilePage />} />
+                  <Route path="/settings" element={<Settings toggleDarkMode={toggleDarkMode} darkMode={darkMode} />} />
+                  <Route path="/badges" element={<Badges />} />
+                  <Route path="/notes" element={<NoteFilterPage />} />
+                  <Route path="/notes/upload" element={<NoteUploader />} />
+                </Route>
 
-                  {/* Debug routes */}
-                  <Route path="/debug/test-pdf/*" element={<TestPDFDebug />} />
+                {/* Debug routes */}
+                <Route path="/debug/test-pdf/*" element={<TestPDFDebug />} />
 
-                  {/* Unknown URLs fall back to the dashboard (or /login when logged out) */}
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-              </ErrorBoundary>
-            </main>
+                {/* Unknown URLs fall back to the dashboard (or /login when logged out) */}
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Route>
+
+              {/* Immersive study view: full-bleed below the shared header */}
+              <Route element={<FullBleedLayout />}>
+                <Route element={<PrivateRoute />}>
+                  <Route path="/view-note" element={<NoteViewer />} />
+                  <Route path="/view-note/:noteId" element={<NoteViewer />} />
+                </Route>
+              </Route>
+            </Routes>
           </div>
           <CookieConsent />
           <DebugPanel />

--- a/frontend/src/features/notes/NoteCard.tsx
+++ b/frontend/src/features/notes/NoteCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { FaFilePdf, FaFileAlt, FaExclamationCircle, FaEye, FaDownload, FaStar, FaFileWord, FaFilePowerpoint, FaFileExcel } from 'react-icons/fa';
+import { FaFilePdf, FaFileAlt, FaExclamationCircle, FaEye, FaDownload, FaStar, FaFileWord, FaFilePowerpoint, FaFileExcel, FaCheckCircle } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import type { Note } from 'types/note';
 import { useStreak } from '../../hooks/useStreak';
@@ -97,6 +97,8 @@ interface NoteCardProps {
   onDelete?: (note: Note) => void;
   compact?: boolean;
   className?: string;
+  /** Whether the current user has completed a study session on this note */
+  studied?: boolean;
 }
 
 const getIcon = (fileType?: string) => {
@@ -125,7 +127,8 @@ const NoteCard: React.FC<NoteCardProps> = ({
   onEdit,
   onDelete,
   compact = false,
-  className = ''
+  className = '',
+  studied = false
 }) => {
   // Handle invalid note prop
   if (!note || typeof note !== 'object') {
@@ -186,11 +189,11 @@ const NoteCard: React.FC<NoteCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
-      className={`group bg-white dark:bg-slate-800 rounded-xl shadow-sm hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-200 dark:border-slate-700 flex flex-col ${compact ? 'h-full' : ''} ${className}`}
+      className={`group bg-white dark:bg-slate-800 rounded-xl shadow-sm hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-200 dark:border-slate-700 flex flex-col h-full ${className}`}
     >
       {/* Header: subject-tinted banner with a single pill and one file icon */}
       <div
-        className={`${compact ? 'h-28' : 'h-36'} relative cursor-pointer flex items-center justify-center ${colorTheme.light} ${colorTheme.dark}`}
+        className={`${compact ? 'h-28' : 'h-36'} shrink-0 relative cursor-pointer flex items-center justify-center ${colorTheme.light} ${colorTheme.dark}`}
         onClick={handleView}
       >
         {isImage && note.fileUrl ? (
@@ -206,23 +209,27 @@ const NoteCard: React.FC<NoteCardProps> = ({
         <span className={`absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-medium shadow-sm bg-white/95 dark:bg-slate-900/80 ${colorTheme.text} ${colorTheme.darkText}`}>
           {note.subject}
         </span>
+        {studied && (
+          <span className="absolute top-3 right-3 flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium shadow-sm bg-green-100/95 text-green-700 dark:bg-green-900/80 dark:text-green-300">
+            <FaCheckCircle aria-hidden="true" /> Studied
+          </span>
+        )}
       </div>
 
-      {/* Body: title once, one quiet meta line, description only if present */}
+      {/* Body: fixed-height blocks so every card in a row is the same size
+          regardless of title/description length */}
       <div className="p-4 flex-grow">
-        <h3 className="font-semibold text-lg text-gray-900 dark:text-white line-clamp-2">
+        <h3 className="font-semibold text-lg leading-snug text-gray-900 dark:text-white line-clamp-2 min-h-[3.25rem]">
           {getTitle()}
         </h3>
-        <div className="mt-1 flex items-center flex-wrap gap-x-1.5 text-xs text-gray-500 dark:text-gray-400">
+        <div className="mt-1 flex items-center flex-wrap gap-x-1.5 text-xs text-gray-500 dark:text-gray-400 min-h-[1rem]">
           {formattedDate && <span>{formattedDate}</span>}
           {formattedDate && note.isPublic && <span aria-hidden="true">&middot;</span>}
           {note.isPublic && <span className="text-green-600 dark:text-green-400 font-medium">Public</span>}
         </div>
-        {description && (
-          <p className="mt-2 text-gray-600 dark:text-gray-300 text-sm line-clamp-2">
-            {description}
-          </p>
-        )}
+        <p className="mt-2 text-gray-600 dark:text-gray-300 text-sm line-clamp-2 min-h-[2.5rem]">
+          {description}
+        </p>
       </div>
 
       {/* Footer: stats and rating on the left, action on the right */}

--- a/frontend/src/features/notes/NoteFilterPage.tsx
+++ b/frontend/src/features/notes/NoteFilterPage.tsx
@@ -8,6 +8,7 @@ import NoteCard from './NoteCard';
 import NoteDetailModal from './components/NoteDetailModal';
 import { subjectColors } from './NoteCard'; // For subjects list, can be moved to a shared config
 import { toast } from 'react-hot-toast';
+import { useUser } from '../user/useUser';
 
 // Extract subject names for the filter form
 const subjectsArray = Object.keys(subjectColors).filter(key => key !== 'default');
@@ -42,6 +43,9 @@ const EmptyState: React.FC<{ hasFilters: boolean; onClearFilters: () => void }> 
 
 const NoteFilterPage: React.FC = () => {
   const { fetchNotes, loading, error } = useNote();
+  const { profile } = useUser();
+  // Notes this user has finished a study session on (drives the card chip)
+  const studiedNoteIds = new Set((profile?.studiedNotes ?? []).map(sn => sn.note));
   const [notes, setNotes] = useState<Note[]>([]);
   const [filters, setFilters] = useState<NoteFilterType>({
     subject: '',
@@ -155,12 +159,12 @@ const NoteFilterPage: React.FC = () => {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.9 }}
                 transition={{ duration: 0.2 }}
+                className="h-full"
               >
-                <NoteCard 
-                  note={note} 
-                  onView={() => handleViewNote(note)} 
-                  // Pass onRatingChange if NoteCard needs to inform parent of rating hook usage
-                  // For now, NoteDetailModal handles rating via its own hook instance
+                <NoteCard
+                  note={note}
+                  studied={studiedNoteIds.has(note._id)}
+                  onView={() => handleViewNote(note)}
                 />
               </motion.div>
             ))}

--- a/frontend/src/features/notes/components/NoteStudySession.tsx
+++ b/frontend/src/features/notes/components/NoteStudySession.tsx
@@ -1,20 +1,13 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { FaClock, FaPause, FaPlay, FaCoffee, FaStopwatch } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import {
+  FaClock, FaPause, FaPlay, FaCoffee, FaStopwatch, FaTimes, FaDownload,
+  FaStar, FaCheckCircle, FaFire, FaTrophy, FaHourglassHalf
+} from 'react-icons/fa';
 import { Note } from '../../types/note';
-// import FinishStudyingButton from '../../progress/FinishStudyingButton'; // Assuming this will be converted/available
-// For now, let's create a placeholder for FinishStudyingButton if it's not critical for this step
-
-interface FinishStudyingButtonProps {
-  noteId: string | undefined;
-  onFinish: (studyData: any) => void; // Define a proper type for studyData later
-  initialStartTime: number;
-  subject: string | undefined;
-}
-const FinishStudyingButtonPlaceholder: React.FC<FinishStudyingButtonProps> = ({ onFinish }) => (
-  <button onClick={() => onFinish({ timeSpent: 10, focusScore: 0.8 })} className="btn btn-success w-full">
-    Finish Studying (Placeholder)
-  </button>
-);
+import { useUser, StudyCompletionResult } from '../../user/useUser';
+import { useNote } from '../useNote';
 
 const formatTime = (timeInSeconds: number): string => {
   const hours = Math.floor(timeInSeconds / 3600);
@@ -23,40 +16,41 @@ const formatTime = (timeInSeconds: number): string => {
   return [hours, minutes, seconds].map((v) => v.toString().padStart(2, '0')).join(':');
 };
 
-// Placeholder for getAIPref if not immediately refactoring localStorage access
-// const getAIPref = (): string => {
-//   return localStorage.getItem('aiFeaturesLocation') || 'both'; 
-// };
+const POMODORO_FOCUS_SECONDS = 25 * 60;
+const POMODORO_BREAK_SECONDS = 5 * 60;
 
 interface NoteStudySessionProps {
   note: Note | null;
-  onClose?: () => void;
-  className?: string;
+  open: boolean;
+  onClose: () => void;
 }
 
-const NoteStudySession: React.FC<NoteStudySessionProps> = ({
-  note,
-  onClose,
-  className = ''
-}) => {
+const NoteStudySession: React.FC<NoteStudySessionProps> = ({ note, open, onClose }) => {
   if (!note) {
     return null;
   }
 
-  const [sessionTime, setSessionTime] = useState<number>(0); 
-  const [breakTime, setBreakTime] = useState<number>(0); 
+  const navigate = useNavigate();
+  const { completeStudy } = useUser();
+  const { rateNote, incrementDownloadCount } = useNote();
+
+  const [sessionTime, setSessionTime] = useState<number>(0);
+  const [breakTime, setBreakTime] = useState<number>(0);
   const [isBreakActive, setIsBreakActive] = useState<boolean>(false);
   const [isPaused, setIsPaused] = useState<boolean>(false);
   const [showBreakOptions, setShowBreakOptions] = useState<boolean>(false);
   const [customTime, setCustomTime] = useState<string>('');
-  const [studyStartTime] = useState<number>(Date.now());
-  // const [aiPref, setAiPref] = useState<string>(getAIPref()); // Placeholder if needed
+  const [pomodoroMode, setPomodoroMode] = useState<boolean>(false);
+  const [finishing, setFinishing] = useState<boolean>(false);
+  const [completion, setCompletion] = useState<StudyCompletionResult | null>(null);
+  const [completedSeconds, setCompletedSeconds] = useState<number>(0);
+  const [userRating, setUserRating] = useState<number>(0);
 
   const sessionTimerRef = useRef<NodeJS.Timeout | null>(null);
   const breakTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (!isPaused && !isBreakActive) {
+    if (!isPaused && !isBreakActive && !completion) {
       sessionTimerRef.current = setInterval(() => {
         setSessionTime((prev) => prev + 1);
       }, 1000);
@@ -64,7 +58,17 @@ const NoteStudySession: React.FC<NoteStudySessionProps> = ({
     return () => {
       if (sessionTimerRef.current) clearInterval(sessionTimerRef.current);
     };
-  }, [isPaused, isBreakActive]);
+  }, [isPaused, isBreakActive, completion]);
+
+  // Pomodoro: after each 25 minutes of focus, automatically start a 5 minute
+  // break so the cycle takes care of itself.
+  useEffect(() => {
+    if (pomodoroMode && sessionTime > 0 && sessionTime % POMODORO_FOCUS_SECONDS === 0 && !isBreakActive) {
+      setBreakTime(POMODORO_BREAK_SECONDS);
+      setIsBreakActive(true);
+      toast('25 minutes of focus done — enjoy a 5 minute break! ☕', { icon: '🍅' });
+    }
+  }, [sessionTime, pomodoroMode, isBreakActive]);
 
   useEffect(() => {
     if (isBreakActive && breakTime > 0) {
@@ -72,14 +76,13 @@ const NoteStudySession: React.FC<NoteStudySessionProps> = ({
         setBreakTime((prev) => {
           if (prev <= 1) {
             setIsBreakActive(false);
-            // Potentially auto-resume session timer or notify user
             return 0;
           }
           return prev - 1;
         });
       }, 1000);
     } else if (breakTimerRef.current) {
-        clearInterval(breakTimerRef.current);
+      clearInterval(breakTimerRef.current);
     }
     return () => {
       if (breakTimerRef.current) clearInterval(breakTimerRef.current);
@@ -91,102 +94,240 @@ const NoteStudySession: React.FC<NoteStudySessionProps> = ({
     setBreakTime(0);
   }, []);
 
-  const startShortBreak = () => {
-    setBreakTime(10 * 60);
-    setIsBreakActive(true);
-    setShowBreakOptions(false);
-  };
-  const startLongBreak = () => {
-    setBreakTime(30 * 60);
+  const startBreak = (minutes: number) => {
+    setBreakTime(minutes * 60);
     setIsBreakActive(true);
     setShowBreakOptions(false);
   };
   const startCustomBreak = () => {
     const minutes = parseInt(customTime);
     if (isNaN(minutes) || minutes <= 0) return;
-    setBreakTime(minutes * 60);
-    setIsBreakActive(true);
-    setShowBreakOptions(false);
+    startBreak(minutes);
     setCustomTime('');
   };
 
   const togglePause = () => setIsPaused((prev) => !prev);
 
-  // const calculateTimeSpentMinutes = (): number => {
-  //   const now = Date.now();
-  //   return Math.round((now - studyStartTime) / (1000 * 60));
-  // };
+  const handleFinishStudying = async () => {
+    if (sessionTime < 5) {
+      toast('Study a little longer before finishing — the timer has barely started!', { icon: '⏳' });
+      return;
+    }
+    setFinishing(true);
+    const result = await completeStudy({ noteId: note._id, duration: sessionTime });
+    setFinishing(false);
+    if (result) {
+      setCompletedSeconds(sessionTime);
+      setCompletion(result);
+    } else {
+      toast.error('Could not save this session. If you just finished one, wait a few minutes and try again.');
+    }
+  };
 
-  // Placeholder for actually finishing and saving the session
-  const handleFinishStudying = (studyData: any) => {
-    console.log('Study session finished:', studyData);
-    console.log('Total session time (seconds): ', sessionTime);
-    // if (onSessionEnd && note) {
-    //   const sessionDataToSave: Partial<NoteStudySessionType> = {
-    //     noteId: note.id,
-    //     userId: 'current_user_id', // Replace with actual user ID from auth context
-    //     startTime: new Date(studyStartTime),
-    //     endTime: new Date(),
-    //     // ... other data like focusScore, flashcardsReviewed if tracked
-    //   };
-    //   onSessionEnd(sessionDataToSave as NoteStudySessionType);
-    // }
+  const handleKeepStudying = () => {
+    setCompletion(null);
+    setSessionTime(0);
+  };
+
+  const handleDownload = async () => {
+    if (!note.fileUrl) {
+      toast.error('This note has no downloadable file.');
+      return;
+    }
+    incrementDownloadCount(note._id); // fire-and-forget count update
+    window.open(note.fileUrl, '_blank', 'noopener');
+  };
+
+  const handleRate = async (value: number) => {
+    setUserRating(value);
+    const result = await rateNote(note._id, value);
+    if (result) {
+      toast.success(`Rated ${value} star${value === 1 ? '' : 's'} — thanks!`);
+    } else {
+      setUserRating(0);
+    }
   };
 
   return (
-    <div className={`note-study-session ${className}`}>
-      <aside className="flex flex-col gap-4 overflow-y-auto max-h-screen p-4 bg-white dark:bg-slate-900 border-r border-gray-200 dark:border-slate-800 min-w-[280px] max-w-[350px] shadow-lg sticky top-0 z-40">
-        <section>
-          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">SESSION TIMER</h3>
-          <div className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-slate-800 rounded-md">
-            <FaClock className="text-primary dark:text-primary-light" />
-            <span className="font-mono text-lg text-gray-700 dark:text-gray-200">{formatTime(sessionTime)}</span>
-            <button onClick={togglePause} className="ml-auto p-2 hover:bg-gray-200 dark:hover:bg-slate-700 rounded-full" aria-label={isPaused ? 'Resume timer' : 'Pause timer'}>
-              {isPaused ? <FaPlay className="text-green-500" /> : <FaPause className="text-yellow-500" />}
-            </button>
-          </div>
-        </section>
-        
-        <section>
-          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">BREAK TIMER</h3>
-          {isBreakActive ? (
-            <div className="flex items-center gap-2 p-2 bg-blue-50 dark:bg-blue-900/30 rounded-md">
-              <FaCoffee className="text-blue-500" />
-              <span className="font-mono text-lg text-blue-700 dark:text-blue-300">{formatTime(breakTime)}</span>
-              <button onClick={cancelBreak} className="ml-auto p-1 bg-red-100 hover:bg-red-200 dark:bg-red-800 dark:hover:bg-red-700 text-red-700 dark:text-red-200 rounded-full text-xs">End</button>
-            </div>
-          ) : (
-            <div className="relative">
-              <button onClick={() => setShowBreakOptions((v) => !v)} className="btn btn-outline btn-sm w-full flex items-center justify-center gap-1">
-                <FaStopwatch /> Take a Break
+    <>
+      {/* Mobile backdrop for the slide-over drawer */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/40 z-40 lg:hidden"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* One instance, two presentations: slide-over drawer below lg,
+          in-flow side column on lg+ (so it can never overlap the PDF). */}
+      <aside
+        className={`bg-white dark:bg-slate-800 border-l border-gray-200 dark:border-slate-700 flex flex-col
+          fixed inset-y-0 right-0 z-50 w-80 shadow-2xl transform transition-transform duration-300
+          ${open ? 'translate-x-0' : 'translate-x-full'}
+          lg:static lg:z-auto lg:shadow-none lg:transform-none lg:transition-none lg:w-80 xl:w-96 lg:shrink-0
+          ${open ? 'lg:flex' : 'lg:hidden'}`}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-slate-700 shrink-0">
+          <h2 className="font-semibold text-gray-800 dark:text-gray-100">Study Session</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-slate-700 text-gray-500 dark:text-gray-400"
+            aria-label="Close study panel"
+          >
+            <FaTimes />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-5 p-4 overflow-y-auto">
+          <section>
+            <h3 className="text-xs font-semibold tracking-wide text-gray-500 dark:text-gray-400 mb-2">SESSION TIMER</h3>
+            <div className="flex items-center gap-2 p-3 bg-gray-50 dark:bg-slate-700/50 rounded-lg">
+              <FaClock className="text-primary dark:text-primary-light" />
+              <span className="font-mono text-xl text-gray-800 dark:text-gray-100">{formatTime(sessionTime)}</span>
+              <button
+                onClick={togglePause}
+                className="ml-auto p-2 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-full"
+                aria-label={isPaused ? 'Resume timer' : 'Pause timer'}
+              >
+                {isPaused ? <FaPlay className="text-green-500" /> : <FaPause className="text-yellow-500" />}
               </button>
-              {showBreakOptions && (
-                <div className="absolute mt-1 w-full bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-xl p-3 z-50 flex flex-col gap-2">
-                  <button onClick={startShortBreak} className="w-full text-left px-3 py-2 hover:bg-blue-100 dark:hover:bg-slate-700 rounded">Short Break (10 min)</button>
-                  <button onClick={startLongBreak} className="w-full text-left px-3 py-2 hover:bg-blue-100 dark:hover:bg-slate-700 rounded">Long Break (30 min)</button>
-                  <div className="flex items-center gap-2 pt-1 border-t border-gray-200 dark:border-slate-700 mt-1">
-                    <input type="number" min="1" value={customTime} onChange={e => setCustomTime(e.target.value)} placeholder="Mins" className="w-1/2 input input-sm dark:bg-slate-700" />
-                    <button onClick={startCustomBreak} className="btn btn-primary btn-sm flex-grow" disabled={!customTime || isNaN(parseInt(customTime)) || parseInt(customTime) <= 0}>Set Custom</button>
-                  </div>
-                </div>
-              )}
             </div>
-          )}
-        </section>
-        
-        <section>
-           <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">ACTIONS</h3>
-          <FinishStudyingButtonPlaceholder
-            noteId={note?._id}
-            onFinish={handleFinishStudying} // Replace with actual onFinish from props if session data is saved
-            initialStartTime={studyStartTime}
-            subject={note?.subject}
-          />
-        </section>
-        
+            <label className="mt-2 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={pomodoroMode}
+                onChange={(e) => setPomodoroMode(e.target.checked)}
+                className="rounded border-gray-300 dark:border-slate-600"
+              />
+              <span>🍅 Pomodoro mode (25 min focus / 5 min break)</span>
+            </label>
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold tracking-wide text-gray-500 dark:text-gray-400 mb-2">BREAK TIMER</h3>
+            {isBreakActive ? (
+              <div className="flex items-center gap-2 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
+                <FaCoffee className="text-blue-500" />
+                <span className="font-mono text-xl text-blue-700 dark:text-blue-300">{formatTime(breakTime)}</span>
+                <button
+                  onClick={cancelBreak}
+                  className="ml-auto px-2 py-1 bg-red-100 hover:bg-red-200 dark:bg-red-800 dark:hover:bg-red-700 text-red-700 dark:text-red-200 rounded-full text-xs font-medium"
+                >
+                  End
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <button
+                  onClick={() => setShowBreakOptions((v) => !v)}
+                  className="btn btn-outline btn-sm w-full flex items-center justify-center gap-1"
+                >
+                  <FaStopwatch /> Take a Break
+                </button>
+                {showBreakOptions && (
+                  <div className="absolute mt-1 w-full bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-xl p-3 z-10 flex flex-col gap-2">
+                    <button onClick={() => startBreak(5)} className="w-full text-left px-3 py-2 hover:bg-blue-50 dark:hover:bg-slate-700 rounded">Quick Break (5 min)</button>
+                    <button onClick={() => startBreak(10)} className="w-full text-left px-3 py-2 hover:bg-blue-50 dark:hover:bg-slate-700 rounded">Short Break (10 min)</button>
+                    <button onClick={() => startBreak(30)} className="w-full text-left px-3 py-2 hover:bg-blue-50 dark:hover:bg-slate-700 rounded">Long Break (30 min)</button>
+                    <div className="flex items-center gap-2 pt-2 border-t border-gray-200 dark:border-slate-700">
+                      <input
+                        type="number"
+                        min="1"
+                        value={customTime}
+                        onChange={(e) => setCustomTime(e.target.value)}
+                        placeholder="Mins"
+                        className="w-1/2 input input-sm dark:bg-slate-700 dark:text-gray-100"
+                      />
+                      <button
+                        onClick={startCustomBreak}
+                        className="btn btn-primary btn-sm flex-grow"
+                        disabled={!customTime || isNaN(parseInt(customTime)) || parseInt(customTime) <= 0}
+                      >
+                        Set
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold tracking-wide text-gray-500 dark:text-gray-400 mb-2">RATE THIS NOTE</h3>
+            <div className="flex items-center gap-1 p-1">
+              {[1, 2, 3, 4, 5].map((star) => (
+                <button
+                  key={star}
+                  onClick={() => handleRate(star)}
+                  className="p-1 transition-transform hover:scale-125"
+                  aria-label={`Rate ${star} star${star === 1 ? '' : 's'}`}
+                >
+                  <FaStar className={`text-xl ${star <= userRating ? 'text-yellow-400' : 'text-gray-300 dark:text-slate-600'}`} />
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-auto">
+            <h3 className="text-xs font-semibold tracking-wide text-gray-500 dark:text-gray-400 mb-2">ACTIONS</h3>
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={handleDownload}
+                className="btn btn-outline w-full flex items-center justify-center gap-2"
+              >
+                <FaDownload /> Download PDF
+              </button>
+              <button
+                onClick={handleFinishStudying}
+                disabled={finishing}
+                className="btn btn-success w-full flex items-center justify-center gap-2 disabled:opacity-60"
+              >
+                {finishing ? <FaHourglassHalf className="animate-pulse" /> : <FaCheckCircle />}
+                {finishing ? 'Saving session…' : 'Finish Studying'}
+              </button>
+            </div>
+          </section>
+        </div>
       </aside>
-    </div>
+
+      {/* Completion summary modal */}
+      {completion && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl max-w-sm w-full p-6 text-center">
+            <div className="mx-auto w-16 h-16 bg-green-100 dark:bg-green-900/40 rounded-full flex items-center justify-center mb-4">
+              <FaCheckCircle className="text-3xl text-green-600 dark:text-green-400" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Session complete!</h2>
+            <p className="text-gray-600 dark:text-gray-300 mb-5">
+              You studied <span className="font-semibold">"{note.title}"</span> for {formatTime(completedSeconds)}.
+            </p>
+            <div className="grid grid-cols-2 gap-3 mb-6">
+              <div className="p-3 rounded-xl bg-amber-50 dark:bg-amber-900/30">
+                <div className="text-2xl font-bold text-amber-600 dark:text-amber-400">+{completion.xpEarned}</div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">XP earned</div>
+              </div>
+              <div className="p-3 rounded-xl bg-orange-50 dark:bg-orange-900/30">
+                <div className="text-2xl font-bold text-orange-600 dark:text-orange-400 flex items-center justify-center gap-1">
+                  <FaFire /> {completion.streak?.current ?? 1}
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">day streak</div>
+              </div>
+            </div>
+            {completion.newBadges.length > 0 && (
+              <div className="mb-6 p-3 rounded-xl bg-violet-50 dark:bg-violet-900/30 flex items-center justify-center gap-2 text-violet-700 dark:text-violet-300">
+                <FaTrophy /> New badge{completion.newBadges.length > 1 ? 's' : ''} earned!
+              </div>
+            )}
+            <div className="flex gap-3">
+              <button onClick={handleKeepStudying} className="btn btn-outline flex-1">Keep Studying</button>
+              <button onClick={() => navigate('/notes')} className="btn btn-primary flex-1">Back to Notes</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 
-export default NoteStudySession; 
+export default NoteStudySession;

--- a/frontend/src/features/user/useUser.ts
+++ b/frontend/src/features/user/useUser.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { callAuthenticatedApi } from '../../api/apiClient';
-import { UserProfile, CompleteStudyPayload } from './userTypes';
+import { UserProfile, CompleteStudyPayload, StudyCompletionResult } from './userTypes';
+
+export type { StudyCompletionResult };
 import { toast } from 'react-hot-toast';
 
 export const useUser = () => {
@@ -75,34 +77,35 @@ export const useUser = () => {
   }, [profile?.badges, lastFetchTime]);
 
   // Log note study completion
-  const completeStudy = useCallback(async (payload: CompleteStudyPayload): Promise<boolean> => {
+  const completeStudy = useCallback(async (payload: CompleteStudyPayload): Promise<StudyCompletionResult | null> => {
     // Prevent XP farming by checking if study was already completed recently
     const noteId = payload.noteId;
     const now = Date.now();
-    
+
     // Check if there's a cooldown timer for this note
     if (studyCompletionTimers.current[noteId]) {
       const timeSinceLastCompletion = now - studyCompletionTimers.current[noteId];
-      
+
       // If less than 5 minutes (300000ms) have passed, prevent completion
       if (timeSinceLastCompletion < 300000) {
         console.log(`Study completion for note ${noteId} throttled. Try again later.`);
-        return false;
+        return null;
       }
     }
-    
+
     // Set loading state
     setLoading(true);
     setError(null);
-    
+
     try {
-      // Backend: POST /users/study-complete
-      // -> { success, data: { message, user: { streak, lastActive } } }
+      // Backend: POST /users/study-complete -> { success, data: { message,
+      // xpEarned, user: { streak, xp, level }, studiedNote, newBadges } }
       const response = await callAuthenticatedApi<{
         message?: string;
-        user?: { streak?: any; lastActive?: string };
+        user?: { streak?: any; xp?: number; level?: number; lastActive?: string };
         xpEarned?: number;
-        awardedBadges?: any[];
+        studiedNote?: StudyCompletionResult['studiedNote'];
+        newBadges?: unknown[];
       }>(
         '/users/study-complete',
         'POST',
@@ -120,23 +123,27 @@ export const useUser = () => {
           setTimeout(() => setNewXp(0), 5000); // Reset after animation completes
         }
 
-        // Track newly awarded badges (when provided by the backend)
-        const awardedBadges = response.data?.awardedBadges ?? [];
-        if (awardedBadges.length > 0) {
-          const badgeIds = awardedBadges.map((badge: any) => badge.badge);
-          setNewBadgeIds(badgeIds);
+        const newBadges = response.data?.newBadges ?? [];
+        if (newBadges.length > 0) {
+          setNewBadgeIds(newBadges.map((b: any) => (typeof b === 'string' ? b : b?.badge)));
           setTimeout(() => setNewBadgeIds([]), 10000); // Reset after animation completes
         }
 
-        // Refresh user profile to get updated XP, badges, streak, etc.
+        // Refresh user profile to get updated XP, badges, streak and the
+        // studiedNotes list (which marks cards as studied).
         await fetchUserProfile(true);
-        return true;
+        return {
+          xpEarned,
+          streak: response.data?.user?.streak ?? null,
+          newBadges,
+          studiedNote: response.data?.studiedNote ?? null
+        };
       }
 
       throw new Error(response.error || 'Failed to log study completion');
     } catch (err: any) {
       setError(err.message || 'Failed to log study completion');
-      return false;
+      return null;
     } finally {
       setLoading(false);
     }

--- a/frontend/src/features/user/userTypes.ts
+++ b/frontend/src/features/user/userTypes.ts
@@ -47,14 +47,31 @@ export interface UserProfile {
   updatedAt: string;
   emailVerified: boolean;
   favoriteNotes: string[];
-  totalSummariesGenerated: number;
-  totalFlashcardsGenerated: number;
-  summaryQuota?: number;
-  flashcardQuota?: number;
+  studiedNotes?: UserStudiedNote[];
+}
+
+/** Per-note study record carried on the profile */
+export interface UserStudiedNote {
+  note: string;
+  lastStudiedAt: string;
+  totalSeconds: number;
+  timesStudied: number;
 }
 
 export interface CompleteStudyPayload {
   noteId: string;
+  /** Seconds spent studying in this session */
   duration: number;
-  pointsEarned: number;
+}
+
+/** What the backend reports after logging a study session */
+export interface StudyCompletionResult {
+  xpEarned: number;
+  streak: { current: number; max: number } | null;
+  newBadges: unknown[];
+  studiedNote: {
+    noteId: string;
+    timesStudied: number;
+    totalSeconds: number;
+  } | null;
 }

--- a/frontend/src/pages/NoteViewer.tsx
+++ b/frontend/src/pages/NoteViewer.tsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, FC, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { FaSpinner, FaExclamationTriangle, FaCoffee, FaTimes } from 'react-icons/fa';
+import { FaSpinner, FaExclamationTriangle, FaArrowLeft, FaStopwatch } from 'react-icons/fa';
 
 import PDFViewer from '../features/notes/PDFViewer'; // Updated path
 import ErrorBoundary from '../components/ErrorBoundary'; // Already TSX
 import usePDFNote from '../hooks/usePDFNote'; // Updated path (TS version)
 import NoteStudySession from '../features/notes/components/NoteStudySession'; // Updated path
-import Sidebar from '../components/layout/Sidebar'; // Updated path to TSX version
 
 // Assuming Note type might be similar to what useNote.ts uses, or define a local one
 // For simplicity, using a local one here based on usage.
@@ -23,12 +22,6 @@ interface Note {
   fileType?: string;
   // Add other fields like context, public_id etc. if they are directly accessed on `note`
   [key: string]: any; // To accommodate various shapes from localStorage/API
-}
-
-interface BreakState {
-  isBreakActive: boolean;
-  breakTime: number;
-  cancelBreak: () => void;
 }
 
 // Utility function to ensure string values
@@ -50,15 +43,11 @@ const NoteViewer: FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [note, setNote] = useState<Note | null>(null);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const [studySessionOpen, setStudySessionOpen] = useState(true); // For the NoteStudySession panel
-
-  // Placeholder for break state logic, to be refined
-  const [breakState, setBreakState] = useState<BreakState>({
-    isBreakActive: false,
-    breakTime: 0,
-    cancelBreak: () => setBreakState(prev => ({ ...prev, isBreakActive: false, breakTime: 0 })),
-  });
+  // Panel starts open on desktop where it sits beside the PDF; on small
+  // screens it is a slide-over the user summons, so start closed there.
+  const [studySessionOpen, setStudySessionOpen] = useState<boolean>(
+    () => typeof window === 'undefined' || window.innerWidth >= 1024
+  );
 
   const getNoteIdFromUrl = useCallback((): string | null => {
     try {
@@ -211,13 +200,6 @@ const NoteViewer: FC = () => {
   const finalNoteTitle = hookNoteTitle || (note && (note.title || note.noteTitle || (note.context && note.context.caption))) || 'Untitled Note';
   const finalNoteId = hookNoteId || (note && (note._id || note.id || note.asset_id)) || null;
 
-  // Break overlay
-  if (breakState.isBreakActive) {
-    return (
-      <div className="fixed inset-0 bg-blue-900/90 flex items-center justify-center z-[100]"><div className="bg-white dark:bg-slate-800 p-8 rounded-xl shadow-2xl max-w-md text-center"><div className="mx-auto w-16 h-16 bg-blue-100 dark:bg-blue-900/50 rounded-full flex items-center justify-center mb-4"><FaCoffee className="text-3xl text-blue-600 dark:text-blue-400" /></div><h2 className="text-2xl font-bold mb-2 text-gray-800 dark:text-gray-100">Taking a Break</h2><p className="text-gray-600 dark:text-gray-300 mb-6">Study session paused. Time remaining: {formatTime(breakState.breakTime)}</p><button onClick={breakState.cancelBreak} className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg font-medium flex items-center justify-center mx-auto"><FaTimes className="mr-2" />End Break</button></div></div>
-    );
-  }
-
   const ErrorFallbackPDF: FC<{ error: Error }> = ({ error: pdfError }) => (
     <div className="p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg text-center">
       <FaExclamationTriangle className="text-red-500 dark:text-red-400 text-3xl mx-auto mb-2" />
@@ -249,40 +231,42 @@ const NoteViewer: FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-gray-100 dark:bg-slate-900">
-      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
-      <div className={`flex-1 flex flex-col transition-all duration-300 ${isSidebarOpen ? 'ml-64' : 'ml-0'}`}>
-        <header className="bg-white dark:bg-slate-800 shadow-sm p-4 flex justify-between items-center">
-          <h1 className="text-xl font-semibold text-gray-800 dark:text-gray-100 truncate max-w-md">{finalNoteTitle}</h1>
-          <button onClick={() => setStudySessionOpen(!studySessionOpen)} className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-primary">
-            <FaCoffee className="text-gray-600 dark:text-gray-300" />
-          </button>
-        </header>
-        <main className="flex-1 p-0 overflow-hidden relative">
-          <div className="h-full w-full">{renderMainContent()}</div>
-        </main>
+    <div className="flex-1 flex flex-col min-h-0 bg-gray-100 dark:bg-slate-900">
+      {/* Compact toolbar: back, title, study-panel toggle */}
+      <div className="flex items-center gap-3 px-4 py-2.5 bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-slate-700 shrink-0">
+        <button
+          onClick={() => navigate('/notes')}
+          className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-slate-700 text-gray-600 dark:text-gray-300"
+          aria-label="Back to notes"
+        >
+          <FaArrowLeft />
+        </button>
+        <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100 truncate flex-1">{finalNoteTitle}</h1>
+        <button
+          onClick={() => setStudySessionOpen((v) => !v)}
+          className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+            studySessionOpen
+              ? 'bg-primary/10 text-primary dark:text-primary-light'
+              : 'hover:bg-gray-100 dark:hover:bg-slate-700 text-gray-600 dark:text-gray-300'
+          }`}
+          aria-label={studySessionOpen ? 'Hide study panel' : 'Show study panel'}
+        >
+          <FaStopwatch />
+          <span className="hidden sm:inline">Study Session</span>
+        </button>
       </div>
-      {note && studySessionOpen && (
-        <NoteStudySession 
-          note={note} 
-          className={`w-80 xl:w-96 bg-white dark:bg-slate-800 shadow-lg border-l dark:border-slate-700 fixed top-0 right-0 h-full z-40 transform transition-transform duration-300 ease-in-out ${studySessionOpen ? 'translate-x-0' : 'translate-x-full'}`}
-          onClose={() => setStudySessionOpen(false)} 
-          onBreakStart={(time: number) => setBreakState({ 
-            isBreakActive: true, 
-            breakTime: time, 
-            cancelBreak: () => setBreakState(prev => ({...prev, isBreakActive: false, breakTime: 0}))
-          })} 
+
+      {/* PDF beside the in-flow study panel: no overlap by construction */}
+      <div className="flex-1 flex min-h-0">
+        <main className="flex-1 min-w-0 relative">{renderMainContent()}</main>
+        <NoteStudySession
+          note={note}
+          open={studySessionOpen}
+          onClose={() => setStudySessionOpen(false)}
         />
-      )}
+      </div>
     </div>
   );
 };
-
-// Helper function (remains JS for now, or can be typed)
-function formatTime(timeInSeconds: number): string {
-  const minutes = Math.floor(timeInSeconds / 60);
-  const seconds = timeInSeconds % 60;
-  return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
-}
 
 export default NoteViewer; 

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -1,110 +1,27 @@
 import React, { useState, useEffect, FC, ReactNode } from 'react';
 import { motion } from 'framer-motion';
-import { FaTrophy, FaFire, FaStar, FaBook, FaCalendarAlt, FaUsers, FaChartBar, FaSpinner } from 'react-icons/fa'; // Added more icons and FaSpinner
+import { Link } from 'react-router-dom';
+import { FaFire, FaStar, FaBook, FaClock, FaSpinner, FaBookOpen } from 'react-icons/fa';
 import { useUser } from '../features/user/useUser';
-
-import SubjectCard from '../components/progress/SubjectCard'; // Already TSX
-import StudyRecommendation from '../components/progress/StudyRecommendation'; // Already TSX
-import FocusBar from '../components/progress/FocusBar'; // Already TSX
-import MotivationCards from '../components/progress/MotivationCards'; // Already TSX
-
-// --- Interfaces and Types ---
+import { useNote } from '../features/notes/useNote';
+import { useStreak } from '../hooks/useStreak';
+import { getSubjectColor } from '../features/notes/NoteCard';
+import FocusBar from '../components/progress/FocusBar';
+import type { Note } from '../types/note';
 
 interface StatsCardProps {
   title: string;
   value: string | number;
   icon: ReactNode;
-  color: string; // Tailwind text color class, e.g., 'text-blue-500'
+  color: string; // Tailwind text color class, e.g. 'text-orange-500'
 }
-
-interface StoredNoteFeedback {
-  emoji: string;
-  timestamp: string; // ISO Date string
-}
-
-interface StoredCompletedNote {
-  id: string; // Corresponds to Note._id or Note.asset_id
-  title?: string;
-  subject?: string;
-  completedAt: string; // ISO Date string
-  timeSpent: number; // in minutes typically
-  feedback?: string; // Emoji string e.g. "🤓"
-  // Deprecated feedback storage
-  feedbacks?: StoredNoteFeedback[]; // Array of feedback objects
-}
-
-interface StoredNote {
-  _id: string;
-  asset_id?: string;
-  title?: string;
-  subject?: string;
-  secure_url?: string;
-  fileUrl?: string;
-  url?: string;
-  // other fields from actual note structure
-}
-
-interface SubjectEmojiStats {
-  [emoji: string]: number;
-}
-
-interface SubjectProgressDetail {
-  completed: number;
-  total: number;
-  timeSpent: number; // in minutes
-  avgTime: string; // Formatted string e.g., "30 min"
-  emojiStats: SubjectEmojiStats;
-  lastStudied: Date | null;
-  daysSinceLastStudy?: number;
-  percentage: number;
-}
-
-interface SubjectsData {
-  [subject: string]: SubjectProgressDetail;
-}
-
-interface SubjectTimeData { // For FocusBar
-  [subject: string]: number; // timeSpent in minutes
-}
-
-interface InactiveSubjectInfo {
-  name: string;
-  days: number;
-}
-
-interface ProgressPageData {
-  subjectsData: SubjectsData;
-  subjectTimeData: SubjectTimeData;
-  inactiveSubjects: InactiveSubjectInfo[];
-  completedThisWeek: number;
-  totalCompletedNotes: number;
-  currentStreak: number; // From useStreak
-  xp?: number; // From useStreak
-  xpForNextLevel?: number; // From useStreak
-  subjectProgress: SubjectsData; // Duplicates subjectsData with percentage, could be merged
-}
-
-// Assumed return from useStreak hook (adjust if useStreak.ts provides specific types)
-interface AssumedStreakData {
-  currentStreak: number;
-  xp: number;
-  level?: number; // Optional
-  // ... other streak fields
-}
-interface AssumedUseStreakReturn {
-  streak: AssumedStreakData;
-  getXpForNextLevel: () => number;
-  // ... other methods/properties from useStreak
-}
-
-// --- Components ---
 
 const StatsCard: FC<StatsCardProps> = ({ title, value, icon, color }) => (
   <motion.div
     whileHover={{ scale: 1.03 }}
-    className="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-md flex items-center"
+    className="bg-white dark:bg-slate-800 p-4 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 flex items-center"
   >
-    <div className={`p-3 rounded-full ${color.replace('text-', 'bg-')}/10 mr-3`}> {/* Basic color conversion */}
+    <div className={`p-3 rounded-full ${color.replace('text-', 'bg-')}/10 mr-3`}>
       {icon}
     </div>
     <div>
@@ -114,170 +31,143 @@ const StatsCard: FC<StatsCardProps> = ({ title, value, icon, color }) => (
   </motion.div>
 );
 
+interface SubjectProgress {
+  subject: string;
+  studied: number;
+  total: number;
+  percentage: number;
+  minutes: number;
+}
+
+const formatMinutes = (totalSeconds: number): string => {
+  const minutes = Math.round(totalSeconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+};
+
 const Progress: FC = () => {
-  const { profile, loading } = useUser();
-  const [progressData, setProgressData] = useState<ProgressPageData | null>(null);
+  const { profile, loading: profileLoading } = useUser();
+  const { fetchNotes } = useNote();
+  const { getXpForNextLevel } = useStreak();
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [notesLoading, setNotesLoading] = useState(true);
 
   useEffect(() => {
-    if (!profile) return;
-    // Use backend data from profile instead of localStorage
-    const subjectDataMap: SubjectsData = {};
-    const now = new Date();
-    const validNotesBySubject: { [subject: string]: StoredNote[] } = {};
-
-    // Assume profile.notes contains all notes and profile.completedNotes contains completed notes
-    const allNotes: StoredNote[] = profile.notes || [];
-    const completedNotes: StoredCompletedNote[] = profile.completedNotes || [];
-
-    allNotes.forEach(note => {
-      const noteUrl = note.secure_url || note.fileUrl || note.url || '';
-      const hasValidUrl = typeof noteUrl === 'string' && noteUrl.trim() !== '' && (noteUrl.startsWith('http://') || noteUrl.startsWith('https://'));
-      if (!hasValidUrl) return;
-
-      let subject = note.subject || 'Uncategorized';
-      // Basic subject detection from title (could be improved)
-      if (note.title) {
-        if (note.title.toLowerCase().includes('biology')) subject = 'Biology';
-        else if (note.title.toLowerCase().includes('math')) subject = 'Mathematics'; // Example
+    let mounted = true;
+    (async () => {
+      try {
+        const response = await fetchNotes({} as any);
+        if (mounted && response?.data) setNotes(response.data);
+      } finally {
+        if (mounted) setNotesLoading(false);
       }
-      if (!validNotesBySubject[subject]) validNotesBySubject[subject] = [];
-      validNotesBySubject[subject].push(note);
-    });
+    })();
+    return () => { mounted = false; };
+  }, [fetchNotes]);
 
-    Object.entries(validNotesBySubject).forEach(([subject, notesInSubject]) => {
-      subjectDataMap[subject] = {
-        completed: 0,
-        total: notesInSubject.length,
-        timeSpent: 0,
-        avgTime: '0 min',
-        emojiStats: { "🤓": 0, "🤔": 0, "❗": 0 },
-        lastStudied: null,
-        percentage: 0,
-      };
-    });
-
-    completedNotes.forEach(completedNote => {
-      let subject = completedNote.subject || 'Uncategorized';
-      if (subject.includes('Biology')) subject = 'Biology'; // Normalize
-
-      if (!subjectDataMap[subject] || !validNotesBySubject[subject]) return;
-
-      const isValidCompletion = validNotesBySubject[subject].some(validNote => 
-        validNote._id === completedNote.id || validNote.asset_id === completedNote.id
-      );
-      if (!isValidCompletion) return;
-
-      subjectDataMap[subject].completed++;
-      subjectDataMap[subject].timeSpent += completedNote.timeSpent || 0;
-      if (completedNote.feedback && subjectDataMap[subject].emojiStats[completedNote.feedback] !== undefined) {
-        subjectDataMap[subject].emojiStats[completedNote.feedback]++;
-      }
-      if (completedNote.completedAt) {
-        const completedDate = new Date(completedNote.completedAt);
-        if (!subjectDataMap[subject].lastStudied || completedDate > (subjectDataMap[subject].lastStudied as Date)) {
-          subjectDataMap[subject].lastStudied = completedDate;
-        }
-      }
-    });
-
-    Object.keys(subjectDataMap).forEach(subject => {
-      const data = subjectDataMap[subject];
-      data.avgTime = data.completed > 0 ? `${Math.round(data.timeSpent / data.completed)} min` : '0 min';
-      if (data.lastStudied) {
-        const diffTime = Math.abs(now.getTime() - (data.lastStudied as Date).getTime());
-        data.daysSinceLastStudy = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-      }
-      data.percentage = data.total > 0 ? Math.round((data.completed / data.total) * 100) : 0;
-    });
-
-    const inactiveSubjects: InactiveSubjectInfo[] = Object.entries(subjectDataMap)
-      .filter(([_, data]) => data.completed > 0 && (data.daysSinceLastStudy || 0) > 7)
-      .map(([subjectName, data]) => ({ name: subjectName, days: data.daysSinceLastStudy || 0 }))
-      .sort((a, b) => b.days - a.days);
-
-    const subjectTimeData: SubjectTimeData = {};
-    Object.entries(subjectDataMap).forEach(([subjectName, data]) => {
-      if (data.timeSpent > 0) subjectTimeData[subjectName] = data.timeSpent;
-    });
-
-    const completedThisWeek = completedNotes.filter(note => {
-      if (!note.completedAt) return false;
-      const completedDate = new Date(note.completedAt);
-      const oneWeekAgo = new Date();
-      oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-      return completedDate >= oneWeekAgo;
-    }).length;
-
-    setProgressData({
-      subjectsData: subjectDataMap,
-      subjectTimeData,
-      inactiveSubjects,
-      completedThisWeek,
-      totalCompletedNotes: completedNotes.length,
-      currentStreak: profile.streak?.current || 0,
-      xp: profile.xp,
-      xpForNextLevel: profile.xpForNextLevel,
-      subjectProgress: subjectDataMap,
-    });
-  }, [profile]);
-
-  // Demo data generation needs to accept streak data
-  const getDemoProgressData = (currentStreakData: AssumedStreakData, currentGetXpForNextLevel: () => number): ProgressPageData => {
-    const demoSubjects: SubjectsData = {
-      'Mathematics': { completed: 8, total: 12, timeSpent: 240, avgTime: '30 min', emojiStats: { "🤓": 5, "🤔": 2, "❗": 1 }, lastStudied: new Date(Date.now() - 2 * 24*60*60*1000), daysSinceLastStudy: 2, percentage: 67 },
-      'Physics': { completed: 5, total: 10, timeSpent: 150, avgTime: '30 min', emojiStats: { "🤓": 2, "🤔": 2, "❗": 1 }, lastStudied: new Date(Date.now() - 4 * 24*60*60*1000), daysSinceLastStudy: 4, percentage: 50 },
-      'Chemistry': { completed: 3, total: 8, timeSpent: 75, avgTime: '25 min', emojiStats: { "🤓": 1, "🤔": 1, "❗": 1 }, lastStudied: new Date(Date.now() - 10 * 24*60*60*1000), daysSinceLastStudy: 10, percentage: 38 },
-    };
-    return {
-      subjectsData: demoSubjects,
-      subjectTimeData: { 'Mathematics': 240, 'Physics': 150, 'Chemistry': 75 },
-      inactiveSubjects: [{ name: 'Chemistry', days: 10 }],
-      completedThisWeek: 5,
-      totalCompletedNotes: 16,
-      currentStreak: currentStreakData.currentStreak,
-      xp: currentStreakData.xp,
-      xpForNextLevel: currentGetXpForNextLevel(),
-      subjectProgress: demoSubjects,
-    };
-  };
-
-  if (loading || !progressData) {
+  if (profileLoading || notesLoading || !profile) {
     return (
       <div className="flex items-center justify-center min-h-[calc(100vh-200px)]">
-        {/* Add a proper loading spinner component here if available */}
         <FaSpinner className="animate-spin text-4xl text-primary" />
       </div>
     );
   }
 
-  const { 
-    subjectsData,
-    subjectTimeData,
-    inactiveSubjects, 
-    completedThisWeek, 
-    totalCompletedNotes, 
-    currentStreak,
-    xp,
-    xpForNextLevel,
-  } = progressData;
+  const studiedNotes = profile.studiedNotes ?? [];
+  const studiedIds = new Set(studiedNotes.map(sn => sn.note));
+  const totalStudySeconds = studiedNotes.reduce((sum, sn) => sum + (sn.totalSeconds || 0), 0);
 
-  const overallProgressPercent = totalCompletedNotes > 0 
-    ? Math.round((totalCompletedNotes / (Object.values(subjectsData).reduce((sum, s) => sum + s.total, 0) || 1)) * 100) 
-    : 0;
+  // Join the user's studied records with the note catalogue per subject
+  const bySubject = new Map<string, SubjectProgress>();
+  notes.forEach(note => {
+    const subject = note.subject || 'Uncategorized';
+    const entry = bySubject.get(subject) ?? { subject, studied: 0, total: 0, percentage: 0, minutes: 0 };
+    entry.total += 1;
+    if (studiedIds.has(note._id)) {
+      entry.studied += 1;
+      const record = studiedNotes.find(sn => sn.note === note._id);
+      entry.minutes += Math.round((record?.totalSeconds || 0) / 60);
+    }
+    bySubject.set(subject, entry);
+  });
+  const subjectProgress = [...bySubject.values()]
+    .map(entry => ({ ...entry, percentage: entry.total > 0 ? Math.round((entry.studied / entry.total) * 100) : 0 }))
+    .sort((a, b) => b.percentage - a.percentage);
+
+  const subjectTimeData = Object.fromEntries(
+    subjectProgress.filter(s => s.minutes > 0).map(s => [s.subject, s.minutes])
+  );
+
+  const xp = profile.xp ?? 0;
+  const xpForNextLevel = getXpForNextLevel();
 
   return (
-    <motion.div 
+    <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
       transition={{ duration: 0.3 }}
-      className="container mx-auto px-4 py-8 space-y-8"
+      className="space-y-8"
     >
-      <header className="mb-8">
+      <header>
         <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">Your Progress</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Level {profile.level ?? 1} &middot; {xp} XP{xpForNextLevel > 0 && ` · ${xpForNextLevel} XP to next level`}
+        </p>
       </header>
 
-      {/* Overall Stats Section */}
-      <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <StatsCard title="Current Streak" value={`${currentStreak} days`} icon={<FaFire size={24} className="text-orange-500" />} color="text-orange-500" />
-        <StatsCard title="Total XP" value={`${xp || 0} XP`
+      {/* Overall stats */}
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+        <StatsCard title="Current Streak" value={`${profile.streak?.current ?? 0} days`} icon={<FaFire size={22} className="text-orange-500" />} color="text-orange-500" />
+        <StatsCard title="Total XP" value={xp} icon={<FaStar size={22} className="text-amber-500" />} color="text-amber-500" />
+        <StatsCard title="Notes Studied" value={studiedNotes.length} icon={<FaBook size={22} className="text-violet-500" />} color="text-violet-500" />
+        <StatsCard title="Study Time" value={formatMinutes(totalStudySeconds)} icon={<FaClock size={22} className="text-sky-500" />} color="text-sky-500" />
+      </section>
+
+      {/* Per-subject progress */}
+      <section className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
+        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100 mb-4">Progress by Subject</h2>
+        {subjectProgress.length === 0 ? (
+          <div className="text-center py-10">
+            <FaBookOpen className="text-4xl text-gray-300 dark:text-slate-600 mx-auto mb-3" />
+            <p className="text-gray-500 dark:text-gray-400 mb-4">No notes yet — once notes exist and you study them, your per-subject progress shows up here.</p>
+            <Link to="/notes" className="btn btn-primary inline-block">Browse Notes</Link>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {subjectProgress.map(({ subject, studied, total, percentage, minutes }) => {
+              const theme = getSubjectColor(subject);
+              return (
+                <div key={subject}>
+                  <div className="flex items-center justify-between text-sm mb-1">
+                    <span className={`font-medium ${theme.text} ${theme.darkText}`}>{subject}</span>
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {studied}/{total} studied{minutes > 0 && ` · ${minutes} min`}
+                    </span>
+                  </div>
+                  <div className="h-2.5 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full ${theme.bg} transition-all duration-500`}
+                      style={{ width: `${percentage}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Where the study time goes */}
+      {Object.keys(subjectTimeData).length > 0 && (
+        <section className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
+          <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100 mb-4">Focus Distribution</h2>
+          <FocusBar subjectTimeData={subjectTimeData} />
+        </section>
+      )}
+    </motion.div>
+  );
+};
+
+export default Progress;


### PR DESCRIPTION
PR 2 of 3 from the approved elevation plan.

## Study page layout — gap and overlap fixed structurally
The page used to render its **own second Sidebar** plus `ml-64` *inside* the app shell's `md:ml-64` + `max-w-7xl` main (= the giant dead zone), and floated the timer panel `position: fixed` over the PDF. Now:
- `App.tsx` has two layout routes: **StandardLayout** (padded, width-capped, scrollable) for every normal page, and **FullBleedLayout** for `/view-note` — same sidebar + header, but the study view owns the full area beneath them.
- The study panel is an **in-flow side column** on desktop and a slide-over drawer (with backdrop) below `lg` — overlap is impossible by construction.
- New compact toolbar: back button, title, study-panel toggle.

## "Finish Studying" is real, with backend-persisted studied state
- **Backend:** `User.studiedNotes[]` (`note`, `lastStudiedAt`, `totalSeconds`, `timesStudied`); `POST /users/study-complete` validates the note (404/400), upserts the record, logs a `study` activity (+5 XP), updates the streak, runs badge checks, and returns `{xpEarned, user: {streak, xp, level}, studiedNote, newBadges}`. The `/auth/me` profile now includes `studiedNotes`.
- **Frontend:** finishing saves the actual session seconds and opens a completion modal (time studied, +XP, streak, new badges) with **Keep Studying** / **Back to Notes**. The 5-minute anti-farm throttle stays.
- **Cards:** a green **✓ Studied** chip appears on any note you've completed a session on.

## New session-panel actions (replacing the placeholder)
- ⭐ Rate the note (real `POST /notes/:id/ratings`)
- ⬇ Download PDF (tracks download count)
- ☕ Quick 5-min break preset + 🍅 **Pomodoro mode** (auto 5-min break after every 25 min of focus)

## Uniform note cards
Fixed-height title/meta/description blocks + `h-full` stretch — every card in the grid is the same size regardless of content length.

## Bonus fix: Progress page was a truncated file
`pages/Progress.tsx` ended **mid-line** (never finished; the old feature flag was hiding it) and read profile fields that don't exist. Rewritten against real data: streak/XP/studied/study-time stat tiles, per-subject progress bars from `studiedNotes` × the notes catalogue, and a focus-distribution chart.

## Verification
Backend tsc clean + new supertest cases (happy path, accumulation, validation); frontend build + 14/14 tests green. DB suites run in CI.

https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G)_