### PR TITLE
Bold visual redesign: violet identity, useful dashboard, dark mode fixes (plan PR 3/3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "edu-guardian",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
         "@react-pdf-viewer/core": "^3.12.0",
         "@react-pdf-viewer/default-layout": "^3.12.0",
         "@react-pdf/renderer": "^4.3.0",
@@ -15,7 +16,6 @@
         "@types/axios": "^0.9.36",
         "@types/react-pdf": "^6.2.0",
         "axios": "^1.9.0",
-        "bootstrap": "^5.3.6",
         "cloudinary-react": "^1.8.1",
         "date-fns": "^2.30.0",
         "framer-motion": "^10.16.4",
@@ -769,6 +769,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1080,17 +1089,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-pdf-viewer/attachment": {
@@ -2970,25 +2968,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
     "@react-pdf-viewer/core": "^3.12.0",
     "@react-pdf-viewer/default-layout": "^3.12.0",
     "@react-pdf/renderer": "^4.3.0",
@@ -20,7 +21,6 @@
     "@types/axios": "^0.9.36",
     "@types/react-pdf": "^6.2.0",
     "axios": "^1.9.0",
-    "bootstrap": "^5.3.6",
     "cloudinary-react": "^1.8.1",
     "date-fns": "^2.30.0",
     "framer-motion": "^10.16.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import CookieConsent from './components/ui/CookieConsent';
 import OfflineDetector from './components/ui/OfflineDetector';
 import DebugPanel, { debug } from './components/DebugPanel';
 import NetworkStatusMonitor from './components/ui/NetworkStatusMonitor';
+import { DarkModeContext } from './context/DarkModeContext';
 
 // Make debug function available globally (for console usage)
 if (typeof window !== 'undefined') {
@@ -154,6 +155,7 @@ function App() {
 
   try {
     return (
+      <DarkModeContext.Provider value={darkMode}>
       <AuthProvider>
         <div className={`min-h-screen ${darkMode ? 'bg-slate-900 text-white' : 'bg-gray-50 text-slate-900'}`}>
           <Toaster position="top-right" toastOptions={{
@@ -241,6 +243,7 @@ function App() {
           <DebugPanel />
         </div>
       </AuthProvider>
+      </DarkModeContext.Provider>
     );
   } catch (error) {
     console.error('Critical error in App render:', error);

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -68,26 +68,26 @@ const Header: React.FC<HeaderProps> = ({ toggleDarkMode }) => {
   const unreadCount = sampleNotifications.filter(n => !n.read).length;
 
   return (
-    <header className="bg-white dark:bg-slate-800 shadow-sm border-b dark:border-slate-700">
+    <header className="bg-white/95 dark:bg-slate-800/95 backdrop-blur border-b border-gray-200 dark:border-slate-700 shrink-0 z-30">
       <div className="container mx-auto px-4 py-3">
         <div className="flex justify-between items-center">
           <div className="flex items-center">
             {isAuthenticated ? (
               <>
                 <motion.div
-                  className="bg-primary/10 px-3 py-1 rounded-full flex items-center mr-4"
+                  className="bg-accent/10 px-3 py-1 rounded-full flex items-center mr-3"
                   whileHover={{ scale: 1.05 }}
                   aria-label={`Current streak: ${currentStreak} days`}
                 >
-                  <span className="font-medium text-primary dark:text-primary-light">Streak: {currentStreak} 🔥</span>
+                  <span className="font-medium text-accent-dark dark:text-accent-light">🔥 {currentStreak} day{currentStreak === 1 ? '' : 's'}</span>
                 </motion.div>
 
                 <motion.div
-                  className="bg-secondary/10 px-3 py-1 rounded-full flex items-center"
+                  className="bg-primary/10 px-3 py-1 rounded-full flex items-center"
                   whileHover={{ scale: 1.05 }}
                   aria-label={`Experience points: ${xp}`}
                 >
-                  <span className="font-medium text-secondary dark:text-secondary-light">XP: {xp} ⭐</span>
+                  <span className="font-medium text-primary dark:text-primary-light">⭐ {xp} XP</span>
                 </motion.div>
               </>
             ) : (
@@ -110,7 +110,7 @@ const Header: React.FC<HeaderProps> = ({ toggleDarkMode }) => {
             )}
           </div>
           
-          <div className="text-gray-700 dark:text-gray-200 italic max-w-md hidden md:block">
+          <div className="text-gray-500 dark:text-gray-400 italic text-sm max-w-md hidden md:block truncate">
             "{randomQuote}"
           </div>
           

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -133,8 +133,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
     setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
   };
 
-  const actionButtonClasses = "w-full flex items-center space-x-3 p-3 rounded-md transition-colors text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-slate-700";
-  const disabledButtonClasses = "w-full flex items-center space-x-3 p-3 rounded-md text-sm font-medium text-gray-400 dark:text-gray-500 cursor-not-allowed";
+  const actionButtonClasses = "w-full flex items-center space-x-3 p-3 rounded-md transition-colors text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-white";
+  const disabledButtonClasses = "w-full flex items-center space-x-3 p-3 rounded-md text-sm font-medium text-slate-600 cursor-not-allowed";
 
   const handleAuthAction = (path: string, label: string) => {
     if (label === 'Logout') {
@@ -157,16 +157,16 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
       headerContent = (
         <>
           <Link to="/" className="flex items-center space-x-2">
-            <h1 className="text-2xl font-bold text-primary dark:text-primary-light">EduGuardian</h1>
+            <h1 className="text-2xl font-bold bg-gradient-to-r from-primary-light to-indigo-400 bg-clip-text text-transparent">EduGuardian</h1>
           </Link>
-          <button onClick={toggleSidebar} className="text-gray-600 dark:text-gray-300 hover:text-primary dark:hover:text-primary-light p-1 rounded-md" aria-label="Close sidebar">
+          <button onClick={toggleSidebar} className="text-slate-400 hover:text-primary-light p-1 rounded-md" aria-label="Close sidebar">
             <FaAngleDoubleLeft size={22} />
           </button>
         </>
       );
     } else { // Desktop Collapsed
       headerContent = (
-        <button onClick={toggleSidebar} className="text-primary dark:text-primary-light p-1" aria-label="Open sidebar">
+        <button onClick={toggleSidebar} className="text-primary-light p-1" aria-label="Open sidebar">
           <FaAngleDoubleRight size={22} />
         </button>
       );
@@ -176,9 +176,9 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
       headerContent = (
         <>
           <Link to="/" className="flex items-center space-x-2" onClick={toggleSidebar}> {/* Also close on nav */}
-            <h1 className="text-2xl font-bold text-primary dark:text-primary-light">EduGuardian</h1>
+            <h1 className="text-2xl font-bold bg-gradient-to-r from-primary-light to-indigo-400 bg-clip-text text-transparent">EduGuardian</h1>
           </Link>
-          <button onClick={toggleSidebar} className="text-gray-600 dark:text-gray-300 hover:text-primary dark:hover:text-primary-light p-1 rounded-md" aria-label="Close menu">
+          <button onClick={toggleSidebar} className="text-slate-400 hover:text-primary-light p-1 rounded-md" aria-label="Close menu">
             <FaTimes size={22} />
           </button>
         </>
@@ -219,20 +219,20 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
             animate={{ x: 0, width: currentSidebarActualWidth }}
             exit={{ x: -currentSidebarActualWidth }}
             transition={{ type: 'spring', stiffness: 300, damping: 30, duration: 0.2 }}
-            className={`fixed top-0 left-0 h-full bg-white dark:bg-slate-800 shadow-xl z-[55] flex flex-col border-r border-gray-200 dark:border-slate-700 ${isMobile && !isOpenState ? 'hidden' : ''}`}
+            className={`fixed top-0 left-0 h-full bg-slate-900 shadow-xl z-[55] flex flex-col border-r border-slate-800 ${isMobile && !isOpenState ? 'hidden' : ''}`}
             style={{ width: currentSidebarActualWidth }}
           >
-            <div className={`p-4 border-b border-gray-200 dark:border-slate-700 flex items-center ${(!isMobile && isOpenState) ? 'justify-between' : 'justify-center'}`}>
+            <div className={`p-4 border-b border-slate-800 flex items-center ${(!isMobile && isOpenState) ? 'justify-between' : 'justify-center'}`}>
               {headerContent}
             </div>
 
             {/* Main Scrollable Content - only if sidebar is fully open OR if on mobile (where it's an overlay) */}
             {(isOpenState || (isMobile && isOpenState)) && (
               <div className="flex-1 overflow-y-auto p-4 space-y-4">
-                <div className="bg-gray-50 dark:bg-slate-750 rounded-lg shadow">
+                <div className="bg-slate-800/60 rounded-lg">
                   <button
                     onClick={() => toggleSection('navigation')}
-                    className="w-full flex items-center justify-between p-3 text-left font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-t-lg"
+                    className="w-full flex items-center justify-between p-3 text-left font-semibold text-slate-200 hover:bg-slate-800 rounded-t-lg"
                   >
                     <div className="flex items-center space-x-2">
                       <FaLayerGroup className="text-primary dark:text-primary-light" />
@@ -247,7 +247,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                         animate={{ height: 'auto', opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
                         transition={{ duration: 0.2 }}
-                        className="overflow-hidden p-3 border-t border-gray-200 dark:border-slate-600"
+                        className="overflow-hidden p-3 border-t border-slate-700/60"
                       >
                         <ul className="space-y-1.5">
                           {/* Show regular navigation items with auth requirements */}
@@ -261,8 +261,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                                   to={item.path}
                                   className={`flex items-center p-2.5 rounded-md transition-colors text-sm font-medium ${
                                     location.pathname === item.path
-                                      ? 'bg-primary/10 text-primary dark:text-primary-light dark:bg-primary/20'
-                                      : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600'
+                                      ? 'bg-primary/20 text-primary-light'
+                                      : 'text-slate-300 hover:bg-slate-800 hover:text-white'
                                   }`}
                                   onClick={isMobile ? toggleSidebar : undefined}
                                 >
@@ -274,7 +274,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                           })}
                           
                           {/* Auth section (login/logout) */}
-                          <li className="mt-4 pt-4 border-t border-gray-200 dark:border-slate-600">
+                          <li className="mt-4 pt-4 border-t border-slate-700/60">
                             {authItems.map((item) => (
                               <button
                                 key={item.path}
@@ -296,10 +296,10 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                 {isAuthenticated && onNoteViewPage && note && (
                   <>
                     {/* Metadata Section */}
-                    <div className="bg-gray-50 dark:bg-slate-750 rounded-lg shadow">
+                    <div className="bg-slate-800/60 rounded-lg">
                       <button
                         onClick={() => toggleSection('metadata')}
-                        className="w-full flex items-center justify-between p-3 text-left font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-t-lg"
+                        className="w-full flex items-center justify-between p-3 text-left font-semibold text-slate-200 hover:bg-slate-800 rounded-t-lg"
                       >
                         <div className="flex items-center space-x-2">
                           <FaInfoCircle className="text-blue-500" />
@@ -314,22 +314,22 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                             animate={{ height: 'auto', opacity: 1 }}
                             exit={{ height: 0, opacity: 0 }}
                             transition={{ duration: 0.2 }}
-                            className="overflow-hidden p-4 border-t border-gray-200 dark:border-slate-600"
+                            className="overflow-hidden p-4 border-t border-slate-700/60"
                           >
                             <div className="space-y-2 text-sm">
-                              <p className="font-medium text-gray-700 dark:text-gray-200">Title:</p>
-                              <p className="text-gray-600 dark:text-gray-300">{note?.title || 'Untitled Document'}</p>
+                              <p className="font-medium text-slate-200">Title:</p>
+                              <p className="text-slate-400">{note?.title || 'Untitled Document'}</p>
                               
-                              <p className="font-medium text-gray-700 dark:text-gray-200 mt-3">Subject:</p>
-                              <p className="text-gray-600 dark:text-gray-300">{note?.subject || 'Not specified'}</p>
+                              <p className="font-medium text-slate-200 mt-3">Subject:</p>
+                              <p className="text-slate-400">{note?.subject || 'Not specified'}</p>
                               
-                              <p className="font-medium text-gray-700 dark:text-gray-200 mt-3">Created:</p>
-                              <p className="text-gray-600 dark:text-gray-300">
+                              <p className="font-medium text-slate-200 mt-3">Created:</p>
+                              <p className="text-slate-400">
                                 {note?.createdAt ? new Date(note.createdAt).toLocaleDateString() : 'Unknown'}
                               </p>
                               
-                              <p className="font-medium text-gray-700 dark:text-gray-200 mt-3">Pages:</p>
-                              <p className="text-gray-600 dark:text-gray-300">{note?.pageCount || 'Unknown'}</p>
+                              <p className="font-medium text-slate-200 mt-3">Pages:</p>
+                              <p className="text-slate-400">{note?.pageCount || 'Unknown'}</p>
                             </div>
                           </motion.div>
                         )}
@@ -356,8 +356,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                           title={item.label}
                           className={`flex justify-center items-center p-3 rounded-md transition-colors ${
                             location.pathname === item.path
-                              ? 'bg-primary/10 text-primary dark:text-primary-light dark:bg-primary/20'
-                              : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600'
+                              ? 'bg-primary/20 text-primary-light'
+                              : 'text-slate-300 hover:bg-slate-800 hover:text-white'
                           }`}
                         >
                           {item.icon}
@@ -367,7 +367,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = false, onClose, className, n
                   })}
                   
                   {/* Auth section (login/logout) */}
-                  <li className="mt-4 pt-4 border-t border-gray-200 dark:border-slate-600">
+                  <li className="mt-4 pt-4 border-t border-slate-700/60">
                     {authItems.map((item) => (
                       <button
                         key={item.path}

--- a/frontend/src/context/DarkModeContext.ts
+++ b/frontend/src/context/DarkModeContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+// App.tsx owns the dark-mode state and provides it here so deep components
+// (e.g. the PDF viewer's theme prop) can react without prop drilling.
+export const DarkModeContext = createContext(false);

--- a/frontend/src/features/auth/Login.tsx
+++ b/frontend/src/features/auth/Login.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FormEvent } from 'react';
 import { useNavigate, Link, Navigate } from 'react-router-dom';
+import { FaGraduationCap } from 'react-icons/fa';
 import { useAuthContext } from './AuthContext';
 
 const Login: React.FC = () => {
@@ -32,74 +33,74 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">Sign in to your account</h2>
-        </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {formError && (
-            <div className="rounded-md bg-red-50 p-4">
-              <div className="text-sm text-red-700">{formError}</div>
-            </div>
-          )}
-          <div className="rounded-md shadow-sm -space-y-px">
-      <div>
-              <label htmlFor="email-address" className="sr-only">
+    <div className="min-h-[calc(100vh-8rem)] flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full">
+        <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-card border border-gray-200 dark:border-slate-700 overflow-hidden">
+          {/* Brand banner */}
+          <div className="bg-gradient-to-r from-primary to-indigo-600 px-8 py-8 text-center">
+            <FaGraduationCap className="text-4xl text-white/90 mx-auto mb-2" />
+            <h2 className="text-2xl font-bold text-white">Welcome back</h2>
+            <p className="text-primary-100 text-sm mt-1">Sign in to continue studying</p>
+          </div>
+
+          <form className="p-8 space-y-5" onSubmit={handleSubmit}>
+            {formError && (
+              <div className="rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 p-3">
+                <div className="text-sm text-red-700 dark:text-red-300">{formError}</div>
+              </div>
+            )}
+            <div>
+              <label htmlFor="email-address" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Email address
               </label>
-        <input
+              <input
                 id="email-address"
                 name="email"
-          type="email"
+                type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Email address"
-          value={email}
+                className="input"
+                placeholder="you@example.com"
+                value={email}
                 onChange={(e) => setEmail(e.target.value)}
-        />
-      </div>
-      <div>
-              <label htmlFor="password" className="sr-only">
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Password
               </label>
-        <input
-          id="password"
+              <input
+                id="password"
                 name="password"
-          type="password"
+                type="password"
                 autoComplete="current-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Password"
-          value={password}
+                className="input"
+                placeholder="••••••••"
+                value={password}
                 onChange={(e) => setPassword(e.target.value)}
-        />
-      </div>
-          </div>
+              />
+            </div>
 
-          <div>
-      <button
-        type="submit"
-        disabled={loading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-      >
-              {loading ? 'Signing in...' : 'Sign in'}
-      </button>
-          </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-2.5 px-4 rounded-lg text-white font-medium bg-gradient-to-r from-primary to-indigo-600 hover:from-primary-dark hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary dark:focus:ring-offset-slate-800 transition-all disabled:opacity-60"
+            >
+              {loading ? 'Signing in…' : 'Sign in'}
+            </button>
 
-          <div className="text-sm text-center">
-            <p>
+            <p className="text-sm text-center text-gray-600 dark:text-gray-400">
               Don't have an account?{' '}
-              <Link to="/register" className="font-medium text-indigo-600 hover:text-indigo-500">
+              <Link to="/register" className="font-medium text-primary dark:text-primary-light hover:underline">
                 Register
               </Link>
             </p>
-          </div>
-    </form>
+          </form>
+        </div>
       </div>
     </div>
   );
 };
 
-export default Login; 
+export default Login;

--- a/frontend/src/features/auth/Register.tsx
+++ b/frontend/src/features/auth/Register.tsx
@@ -1,6 +1,36 @@
 import React, { useState, FormEvent } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { FaGraduationCap } from 'react-icons/fa';
 import { useAuthContext } from './AuthContext';
+
+interface FieldProps {
+  id: string;
+  label: string;
+  type: string;
+  autoComplete: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Field: React.FC<FieldProps> = ({ id, label, type, autoComplete, placeholder, value, onChange }) => (
+  <div>
+    <label htmlFor={id} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      {label}
+    </label>
+    <input
+      id={id}
+      name={id}
+      type={type}
+      autoComplete={autoComplete}
+      required
+      className="input"
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  </div>
+);
 
 const Register: React.FC = () => {
   const [name, setName] = useState('');
@@ -15,23 +45,23 @@ const Register: React.FC = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setFormError('');
-    
+
     // Validate form
     if (!name || !username || !email || !password) {
       setFormError('Please fill in all required fields');
       return;
     }
-    
+
     if (password !== confirmPassword) {
       setFormError('Passwords do not match');
       return;
     }
-    
+
     if (password.length < 6) {
       setFormError('Password must be at least 6 characters long');
       return;
     }
-    
+
     try {
       await registerUser({ name, username, email, password });
       // Registration returns a token, so the user is already logged in
@@ -42,122 +72,47 @@ const Register: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">Create your account</h2>
-        </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {formError && (
-            <div className="rounded-md bg-red-50 p-4">
-              <div className="text-sm text-red-700">{formError}</div>
-            </div>
-          )}
-          <div className="rounded-md shadow-sm -space-y-px">
-            <div>
-              <label htmlFor="name" className="sr-only">
-                Full Name
-              </label>
-              <input
-                id="name"
-                name="name"
-                type="text"
-                autoComplete="name"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Full Name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="username" className="sr-only">
-                Username
-              </label>
-              <input
-                id="username"
-                name="username"
-                type="text"
-                autoComplete="username"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="email-address" className="sr-only">
-                Email address
-              </label>
-              <input
-                id="email-address"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Email address"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="sr-only">
-                Password
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="confirm-password" className="sr-only">
-                Confirm Password
-              </label>
-              <input
-                id="confirm-password"
-                name="confirm-password"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Confirm Password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-              />
-            </div>
+    <div className="min-h-[calc(100vh-8rem)] flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full">
+        <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-card border border-gray-200 dark:border-slate-700 overflow-hidden">
+          {/* Brand banner */}
+          <div className="bg-gradient-to-r from-primary to-indigo-600 px-8 py-8 text-center">
+            <FaGraduationCap className="text-4xl text-white/90 mx-auto mb-2" />
+            <h2 className="text-2xl font-bold text-white">Create your account</h2>
+            <p className="text-primary-100 text-sm mt-1">Join EduGuardian and start learning smarter</p>
           </div>
 
-          <div>
+          <form className="p-8 space-y-4" onSubmit={handleSubmit}>
+            {formError && (
+              <div className="rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 p-3">
+                <div className="text-sm text-red-700 dark:text-red-300">{formError}</div>
+              </div>
+            )}
+            <Field id="name" label="Full Name" type="text" autoComplete="name" placeholder="Juan Dela Cruz" value={name} onChange={setName} />
+            <Field id="username" label="Username" type="text" autoComplete="username" placeholder="juandc" value={username} onChange={setUsername} />
+            <Field id="email" label="Email address" type="email" autoComplete="email" placeholder="you@example.com" value={email} onChange={setEmail} />
+            <Field id="password" label="Password" type="password" autoComplete="new-password" placeholder="At least 6 characters" value={password} onChange={setPassword} />
+            <Field id="confirm-password" label="Confirm Password" type="password" autoComplete="new-password" placeholder="Repeat your password" value={confirmPassword} onChange={setConfirmPassword} />
+
             <button
               type="submit"
               disabled={loading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="w-full py-2.5 px-4 rounded-lg text-white font-medium bg-gradient-to-r from-primary to-indigo-600 hover:from-primary-dark hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary dark:focus:ring-offset-slate-800 transition-all disabled:opacity-60"
             >
-              {loading ? 'Creating account...' : 'Sign up'}
+              {loading ? 'Creating account…' : 'Sign up'}
             </button>
-          </div>
-          
-          <div className="text-sm text-center">
-            <p>
+
+            <p className="text-sm text-center text-gray-600 dark:text-gray-400">
               Already have an account?{' '}
-              <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+              <Link to="/login" className="font-medium text-primary dark:text-primary-light hover:underline">
                 Sign in
               </Link>
             </p>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   );
 };
 
-export default Register; 
+export default Register;

--- a/frontend/src/features/notes/PDFViewer.tsx
+++ b/frontend/src/features/notes/PDFViewer.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Viewer, Worker } from '@react-pdf-viewer/core';
 import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
+import { DarkModeContext } from '../../context/DarkModeContext';
 // Bundle the worker that ships with the installed pdfjs-dist so the API and
 // worker versions always match; without a worker the viewer crashes with
 // 'No "GlobalWorkerOptions.workerSrc" specified'.
@@ -20,6 +21,7 @@ interface PDFViewerProps {
 const PDFViewer: React.FC<PDFViewerProps> = ({ fileUrl, noteTitle, noteId, onLoad }) => {
   const [internalFileUrl, setInternalFileUrl] = useState<string | null>(null);
   const [hasError, setHasError] = useState<boolean>(false);
+  const darkMode = useContext(DarkModeContext);
   const defaultLayoutPluginInstance = defaultLayoutPlugin();
 
   useEffect(() => {
@@ -62,6 +64,7 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ fileUrl, noteTitle, noteId, onLoa
         <Viewer
           fileUrl={internalFileUrl}
           plugins={[defaultLayoutPluginInstance]}
+          theme={darkMode ? 'dark' : 'light'}
         />
       </Worker>
     </div>

--- a/frontend/src/hooks/useAntiCheating.tsx
+++ b/frontend/src/hooks/useAntiCheating.tsx
@@ -15,9 +15,9 @@ export const useAntiCheating = () => {
     if (!isActive) return null;
     return (
       <div className="fixed inset-0 bg-black bg-opacity-70 z-50 flex items-center justify-center">
-        <div className="bg-white p-5 rounded-lg shadow-lg max-w-md w-full">
-          <h2 className="text-xl font-bold mb-3">Resting Period</h2>
-          <p>
+        <div className="bg-white dark:bg-slate-800 p-5 rounded-xl shadow-lg max-w-md w-full">
+          <h2 className="text-xl font-bold mb-3 text-gray-900 dark:text-white">Resting Period</h2>
+          <p className="text-gray-600 dark:text-gray-300">
             You've been studying for a while. Take a short break to maintain
             effective learning.
           </p>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,10 +4,10 @@
 
 @layer base {
   :root {
-    --color-primary: #4f46e5;
-    --color-primary-dark: #4338ca;
-    --color-primary-light: #6366f1;
-    
+    --color-primary: #7c3aed;
+    --color-primary-dark: #6d28d9;
+    --color-primary-light: #8b5cf6;
+
     /* Color variables for subjects */
     --red-500: #ef4444;
     --blue-500: #3b82f6;
@@ -35,9 +35,31 @@
 
   /* Dark theme overrides */
   .dark {
-    --color-primary: #818cf8;
-    --color-primary-dark: #6366f1;
-    --color-primary-light: #a5b4fc;
+    --color-primary: #a78bfa;
+    --color-primary-dark: #8b5cf6;
+    --color-primary-light: #c4b5fd;
+  }
+
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Slim, theme-aware scrollbars */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: rgb(148 163 184 / 0.5) transparent;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: rgb(148 163 184 / 0.5);
+    border-radius: 9999px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
   }
 }
 
@@ -45,23 +67,31 @@
   .btn {
     @apply px-4 py-2 rounded-lg font-medium transition-colors;
   }
-  
+
   .btn-primary {
     @apply bg-primary text-white hover:bg-primary-dark;
   }
-  
+
   .btn-secondary {
     @apply bg-secondary text-white hover:bg-secondary-dark;
   }
-  
+
+  .btn-success {
+    @apply bg-green-600 text-white hover:bg-green-700;
+  }
+
+  .btn-outline {
+    @apply border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-700;
+  }
+
   .input {
-    @apply w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-primary;
+    @apply w-full border border-gray-300 dark:border-slate-600 rounded-lg p-2 bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary;
   }
-  
+
   .card {
-    @apply bg-white rounded-lg shadow-md p-4;
+    @apply bg-white dark:bg-slate-800 rounded-xl shadow-card p-4 border border-gray-200 dark:border-slate-700;
   }
-} 
+}
 
 /* Fade in animation for dropdown menus */
 .fade-in {
@@ -78,4 +108,4 @@
     opacity: 1;
     transform: translateY(0);
   }
-} 
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,25 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Toaster } from 'react-hot-toast';
-import 'bootstrap/dist/css/bootstrap.min.css';
+// Inter variable font, self-hosted so there is no runtime CDN dependency
+import '@fontsource-variable/inter';
 import './index.css';
 import App from './App';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+// Note: the themed <Toaster> lives in App.tsx; a second one here caused
+// duplicate toasts.
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Router>
       <App />
-      <Toaster 
-        position="top-right"
-        toastOptions={{
-          duration: 3000,
-          style: {
-            background: '#fff',
-            color: '#334155',
-          },
-        }}
-      />
     </Router>
   </React.StrictMode>
-); 
+);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,137 +1,258 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import { motion } from 'framer-motion';
-import { Link } from 'react-router-dom';
-import { FaUpload, FaSearch, FaChartLine, FaSpinner } from 'react-icons/fa';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  FaUpload, FaSearch, FaChartLine, FaSpinner, FaFire, FaStar, FaBook,
+  FaClock, FaPlay, FaArrowRight
+} from 'react-icons/fa';
 import DashboardFeed from '../features/dashboard/DashboardFeed';
-// Assuming useUser provides the necessary type for profile
 import { useUser } from '../features/user/useUser';
-// Assuming UserStatsCard props match the profile data or define its own interface
-import UserStatsCard from '../features/user/components/UserStatsCard';
-// Import the extracted FeatureCard component
-import FeatureCard from '../components/ui/FeatureCard';
+import { useNote } from '../features/notes/useNote';
+import { useStreak } from '../hooks/useStreak';
+import { getSubjectColor } from '../features/notes/NoteCard';
+import type { Note } from '../types/note';
 
-// Define the structure for a Feature if not defined elsewhere
-interface Feature {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-  to: string;
-  color: string;
+const greetingForHour = (hour: number): string => {
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+};
+
+interface StatTileProps {
+  label: string;
+  value: ReactNode;
+  icon: ReactNode;
+  tint: string; // e.g. 'bg-amber-50 dark:bg-amber-900/20'
+  sub?: ReactNode;
 }
+
+const StatTile: React.FC<StatTileProps> = ({ label, value, icon, tint, sub }) => (
+  <motion.div
+    whileHover={{ y: -2 }}
+    className="bg-white dark:bg-slate-800 rounded-2xl shadow-card border border-gray-200 dark:border-slate-700 p-4 flex flex-col"
+  >
+    <div className="flex items-center justify-between">
+      <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
+      <span className={`p-2 rounded-xl ${tint}`}>{icon}</span>
+    </div>
+    <div className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
+    {sub && <div className="mt-auto pt-2">{sub}</div>}
+  </motion.div>
+);
+
+const formatStudyTime = (totalSeconds: number): string => {
+  const minutes = Math.round(totalSeconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+};
 
 const HomePage: React.FC = () => {
   const { profile, loading } = useUser();
-  const [showWelcome, setShowWelcome] = useState<boolean>(true);
-  
-  useEffect(() => {
-    const hasVisited = localStorage.getItem('hasVisitedDashboard');
-    if (hasVisited) {
-      setShowWelcome(false);
-    } else {
-      localStorage.setItem('hasVisitedDashboard', 'true');
-    }
-  }, []);
+  const { fetchNotes } = useNote();
+  const { getXpForNextLevel } = useStreak();
+  const navigate = useNavigate();
+  const [notes, setNotes] = useState<Note[]>([]);
 
-  // Explicitly type the features array
-  const features: Feature[] = [
-    {
-      icon: <FaUpload className="text-primary" size={24} />,
-      title: "Upload Notes",
-      description: "Share your knowledge by uploading your academic notes to help others learn.",
-      // TODO: Link should probably be /upload or similar, not /donate?
-      to: "/donate",
-      color: "border-primary" // Assumes 'primary' is defined in Tailwind config
-    },
-    {
-      icon: <FaSearch className="text-green-500" size={24} />,
-      title: "Find Study Material",
-      description: "Search and filter through a wide range of notes based on subject, grade, and more.",
-      to: "/my-notes",
-      color: "border-green-500"
-    },
-    {
-      icon: <FaChartLine className="text-purple-500" size={24} />,
-      title: "Track Progress",
-      description: "Monitor your learning journey with XP points and day streaks.",
-      to: "/progress",
-      color: "border-purple-500"
-    }
-  ];
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const response = await fetchNotes({ sortBy: 'date', sortOrder: 'desc' } as any);
+        if (mounted && response?.data) setNotes(response.data);
+      } catch {
+        /* the feed and tiles still render without notes */
+      }
+    })();
+    return () => { mounted = false; };
+  }, [fetchNotes]);
+
+  if (loading && !profile) {
+    return (
+      <div className="p-12 flex items-center justify-center text-gray-600 dark:text-gray-300">
+        <FaSpinner className="animate-spin text-primary mr-3" size={24} />
+        <span>Loading your dashboard...</span>
+      </div>
+    );
+  }
+
+  const firstName = (profile?.name || profile?.username || 'there').split(' ')[0];
+  const today = new Date().toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+
+  const studiedNotes = profile?.studiedNotes ?? [];
+  const totalStudySeconds = studiedNotes.reduce((sum, sn) => sum + (sn.totalSeconds || 0), 0);
+  const xp = profile?.xp ?? 0;
+  const level = profile?.level ?? 1;
+  const xpToNext = getXpForNextLevel();
+  const xpProgressPct = xpToNext > 0 ? Math.min(100, Math.round((xp / (xp + xpToNext)) * 100)) : 100;
+
+  // Continue studying: the most recently studied note, if it still exists
+  const lastStudied = [...studiedNotes].sort(
+    (a, b) => new Date(b.lastStudiedAt).getTime() - new Date(a.lastStudiedAt).getTime()
+  )[0];
+  const continueNote = lastStudied ? notes.find(n => n._id === lastStudied.note) : undefined;
+
+  const recentNotes = notes.slice(0, 4);
 
   return (
-    <div className="space-y-8">
-      {/* User Stats (only when logged in and profile loaded) */}
-      {/* Add explicit checks for profile properties if needed by UserStatsCard */}
-      {profile && (
-        <UserStatsCard xp={profile.xp} level={profile.level} streak={profile.streak} />
-      )}
-      
-      {/* Welcome Message */}
-      {showWelcome && (
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="text-center mb-6"
-        >
-          <h1 className="text-3xl font-bold mb-4 text-gray-900 dark:text-white">Welcome to EduGuardian</h1>
-          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-            Your secure, gamified platform for academic notes and resources.
-          </p>
-        </motion.div>
-      )}
-      
-      {/* Main Content Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Left Side - Activity Feed */}
-        <div className="lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-bold mb-4 text-gray-900 dark:text-white">Activity Feed</h2>
-          {loading ? (
-            <div className="p-12 flex items-center justify-center text-gray-600 dark:text-gray-300">
-              <FaSpinner className="animate-spin text-primary mr-3" size={24} />
-              <span>Loading your dashboard...</span>
-            </div>
-          ) : (
-            // Pass profile data if needed by DashboardFeed
-            <DashboardFeed />
-          )}
+    <div className="space-y-6">
+      {/* Greeting */}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            {greetingForHour(new Date().getHours())}, {firstName} 👋
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">{today}</p>
         </div>
-        
-        {/* Right Side - Quick Actions & Info */}
-        <div className="space-y-6">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Quick Actions</h2>
-          
-          {features.map((feature, index) => (
+        <Link
+          to="/notes"
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-white font-medium bg-gradient-to-r from-primary to-indigo-600 hover:from-primary-dark hover:to-indigo-700 shadow-card transition-all w-fit"
+        >
+          <FaSearch /> Browse Notes
+        </Link>
+      </div>
+
+      {/* Stat tiles */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatTile
+          label={`Level ${level}`}
+          value={`${xp} XP`}
+          icon={<FaStar className="text-primary" />}
+          tint="bg-primary-50 dark:bg-primary-900/20"
+          sub={
+            <div>
+              <div className="h-1.5 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-primary to-indigo-500 transition-all duration-700"
+                  style={{ width: `${xpProgressPct}%` }}
+                />
+              </div>
+              {xpToNext > 0 && (
+                <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{xpToNext} XP to level {level + 1}</p>
+              )}
+            </div>
+          }
+        />
+        <StatTile
+          label="Day Streak"
+          value={`${profile?.streak?.current ?? 0}`}
+          icon={<FaFire className="text-accent" />}
+          tint="bg-amber-50 dark:bg-amber-900/20"
+          sub={<p className="text-[11px] text-gray-400 dark:text-gray-500">best: {profile?.streak?.max ?? 0} days</p>}
+        />
+        <StatTile
+          label="Notes Studied"
+          value={`${studiedNotes.length}`}
+          icon={<FaBook className="text-emerald-500" />}
+          tint="bg-emerald-50 dark:bg-emerald-900/20"
+        />
+        <StatTile
+          label="Study Time"
+          value={formatStudyTime(totalStudySeconds)}
+          icon={<FaClock className="text-sky-500" />}
+          tint="bg-sky-50 dark:bg-sky-900/20"
+        />
+      </div>
+
+      {/* Main grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 space-y-6">
+          {/* Continue studying */}
+          {continueNote && (
             <motion.div
-              key={index}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="relative overflow-hidden rounded-2xl shadow-card border border-primary-200 dark:border-primary-800/50 bg-gradient-to-r from-primary-50 to-indigo-50 dark:from-primary-900/20 dark:to-indigo-900/20 p-5"
+            >
+              <p className="text-xs font-semibold tracking-wide text-primary-dark dark:text-primary-light mb-2">CONTINUE STUDYING</p>
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-lg text-gray-900 dark:text-white truncate">{continueNote.title}</h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                    <span className={`${getSubjectColor(continueNote.subject).text} ${getSubjectColor(continueNote.subject).darkText} font-medium`}>
+                      {continueNote.subject}
+                    </span>
+                    {' '}&middot; studied {lastStudied!.timesStudied}&times; &middot; {formatStudyTime(lastStudied!.totalSeconds)} total
+                  </p>
+                </div>
+                <button
+                  onClick={() => navigate(`/view-note/${continueNote._id}`)}
+                  className="shrink-0 inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-white font-medium bg-gradient-to-r from-primary to-indigo-600 hover:from-primary-dark hover:to-indigo-700 transition-all"
+                >
+                  <FaPlay className="text-sm" /> Resume
+                </button>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Recent notes */}
+          {recentNotes.length > 0 && (
+            <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-card border border-gray-200 dark:border-slate-700 p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white">Recent Notes</h2>
+                <Link to="/notes" className="text-sm font-medium text-primary dark:text-primary-light hover:underline inline-flex items-center gap-1">
+                  View all <FaArrowRight className="text-xs" />
+                </Link>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {recentNotes.map(note => {
+                  const theme = getSubjectColor(note.subject);
+                  return (
+                    <button
+                      key={note._id}
+                      onClick={() => navigate(`/view-note/${note._id}`)}
+                      className="flex items-center gap-3 p-3 rounded-xl border border-gray-100 dark:border-slate-700 hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-card transition-all text-left"
+                    >
+                      <span className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${theme.light} ${theme.dark}`}>
+                        <FaBook className={`${theme.text} ${theme.darkText}`} />
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block font-medium text-sm text-gray-900 dark:text-white truncate">{note.title}</span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400 truncate">{note.subject}</span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Activity feed */}
+          <DashboardFeed />
+        </div>
+
+        {/* Right column */}
+        <div className="space-y-4">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white">Quick Actions</h2>
+
+          {[
+            { icon: <FaUpload className="text-primary" size={20} />, title: 'Upload Notes', description: 'Share your knowledge with other students.', to: '/notes/upload', tint: 'bg-primary-50 dark:bg-primary-900/20' },
+            { icon: <FaSearch className="text-emerald-500" size={20} />, title: 'Find Study Material', description: 'Filter notes by subject, grade and quarter.', to: '/notes', tint: 'bg-emerald-50 dark:bg-emerald-900/20' },
+            { icon: <FaChartLine className="text-accent" size={20} />, title: 'Track Progress', description: 'XP, streaks and per-subject progress.', to: '/progress', tint: 'bg-amber-50 dark:bg-amber-900/20' }
+          ].map((action, index) => (
+            <motion.div
+              key={action.to}
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-              whileHover={{ scale: 1.03 }} // Add subtle hover effect
+              transition={{ duration: 0.4, delay: index * 0.08 }}
             >
-              <Link 
-                to={feature.to}
-                className="flex items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow duration-200"
+              <Link
+                to={action.to}
+                className="flex items-center p-4 bg-white dark:bg-slate-800 rounded-2xl shadow-card border border-gray-200 dark:border-slate-700 hover:shadow-card-hover hover:border-primary-300 dark:hover:border-primary-700 transition-all"
               >
-                {/* Adjusted bg color heuristic */}
-                <div className={`p-3 rounded-full mr-4 ${feature.color.replace('border-', 'bg-')} bg-opacity-10`}>
-                  {feature.icon}
-                </div>
+                <div className={`p-3 rounded-xl mr-4 ${action.tint}`}>{action.icon}</div>
                 <div>
-                  <h3 className="font-medium text-gray-900 dark:text-white">{feature.title}</h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    {feature.description.substring(0, 60)}...
-                  </p>
+                  <h3 className="font-semibold text-gray-900 dark:text-white">{action.title}</h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{action.description}</p>
                 </div>
               </Link>
             </motion.div>
           ))}
-          
-          {/* Did You Know Card */}
-          <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800/50 dark:to-gray-900/30 p-4 rounded-lg border border-blue-200 dark:border-gray-700 shadow-sm">
-            <h3 className="font-medium text-lg mb-2 text-blue-800 dark:text-blue-300">Did You Know?</h3>
-            <p className="text-sm text-blue-700 dark:text-blue-200">
-              You can earn XP and badges by uploading notes, studying regularly, and helping others. Check your <Link to="/badges" className="font-semibold underline hover:text-blue-600 dark:hover:text-blue-100">Badges</Link>!
+
+          <div className="bg-gradient-to-br from-primary to-indigo-600 rounded-2xl p-5 text-white shadow-card">
+            <h3 className="font-semibold text-lg mb-1.5">Did You Know?</h3>
+            <p className="text-sm text-primary-100">
+              You earn XP and badges by uploading notes, studying regularly and keeping your streak alive. Check your{' '}
+              <Link to="/badges" className="font-semibold underline hover:text-white">badges</Link>!
             </p>
           </div>
         </div>
@@ -140,4 +261,4 @@ const HomePage: React.FC = () => {
   );
 };
 
-export default HomePage; 
+export default HomePage;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 const plugin = require('tailwindcss/plugin');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 export default {
   content: [
@@ -9,17 +10,42 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['InterVariable', ...defaultTheme.fontFamily.sans],
+      },
       colors: {
+        // Brand: violet with a full scale; pair with the amber accent for
+        // streak/XP highlights. Gradient identity: from-primary to-indigo-600.
         primary: {
-          DEFAULT: '#4f46e5', // indigo-600
-          light: '#6366f1',   // indigo-500
-          dark: '#4338ca',    // indigo-700
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+          DEFAULT: '#7c3aed', // violet-600
+          light: '#8b5cf6',   // violet-500
+          dark: '#6d28d9',    // violet-700
+        },
+        accent: {
+          DEFAULT: '#f59e0b', // amber-500
+          light: '#fbbf24',   // amber-400
+          dark: '#d97706',    // amber-600
         },
         secondary: {
           DEFAULT: '#64748b', // slate-500
           light: '#94a3b8',   // slate-400
           dark: '#475569',    // slate-600
         },
+      },
+      boxShadow: {
+        // Soft layered card shadow for the elevated look
+        card: '0 1px 2px 0 rgb(0 0 0 / 0.04), 0 4px 16px -4px rgb(0 0 0 / 0.08)',
+        'card-hover': '0 4px 8px -2px rgb(0 0 0 / 0.08), 0 12px 32px -8px rgb(124 58 237 / 0.18)',
       },
     },
   },


### PR DESCRIPTION
PR 3 of 3 from the approved elevation plan — the bold visual redesign.

## 🔙 Rollback safety (as requested)
The pre-redesign look is preserved on branch **`design-v1`** (tag pushes are blocked by branch-scoped credentials, so it's a branch). To go back: revert this PR, or Netlify → Deploys → restore the previous deploy (instant).

## New identity
- **Violet brand** (`#7c3aed`, full 50–900 scale) replacing indigo, with an **amber accent** for streak/XP; CTAs use a violet→indigo gradient
- **Inter variable font**, self-hosted via `@fontsource` (no CDN)
- Soft layered card shadows, `rounded-2xl` surfaces, slim theme-aware scrollbars
- Removed the legacy **bootstrap.min.css** global import (nothing used it — it fought Tailwind on every page) and a duplicate `<Toaster>` causing double toasts

## Chrome
- **Sidebar:** dark brand surface in *both* modes, gradient wordmark, violet active states (also fixes the invalid `dark:bg-slate-750` class)
- **Header:** amber streak pill + violet XP pill, quieter quote, backdrop blur

## Dashboard — actually useful now
- Time-of-day greeting ("Good evening, Krizdarl 👋") + date
- Four stat tiles: **Level + XP progress bar**, **day streak** (with best), **notes studied**, **total study time** — all real data from the new `studiedNotes`
- **Continue Studying** card that resumes your most recent note
- **Recent Notes** grid, the activity feed, restyled Quick Actions (Upload now points at `/notes/upload`, not `/donate`)

## Dark mode fixed
- Login/Register rebuilt as branded gradient-header cards with full dark variants (inputs were white-on-white before)
- Anti-cheat overlay, ErrorFallback, and the `.card`/`.input`/`.btn-outline` component classes are theme-aware
- The **PDF viewer toolbar follows the app theme** (new `DarkModeContext` → `<Viewer theme>`)

## Verification
Frontend build + 14/14 tests green; no backend changes.

https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G)_