### PR TITLE
Fix badge crash that bricked navigation after earning first badges

### DIFF
--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -141,7 +141,7 @@ export class AuthService {
   public async getAuthenticatedUserProfile(userId: string): Promise<Partial<IUser>> {
     const user = await User.findById(userId)
       .select('-password -resetPasswordToken -resetPasswordExpire -emailVerificationToken -emailVerificationTokenExpire')
-      .populate({ path: 'badges.badge', select: 'name description icon rarity' }) // Keep badge population
+      .populate({ path: 'badges.badge', select: 'name description icon rarity category xpReward' }) // Badge fields the UI renders
       .lean(); // Using lean as it is for profile display, not direct update here
 
     if (!user) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Toaster } from 'react-hot-toast';
 import toast from 'react-hot-toast';
@@ -39,25 +39,33 @@ if (typeof window !== 'undefined') {
 
 // Standard chrome: padded, width-capped content column for regular pages.
 // The app shell is h-screen, so this main is the scroll container.
-const StandardLayout: React.FC = () => (
-  <main className="flex-grow min-h-0 overflow-y-auto">
-    <div className="p-4 md:p-6 max-w-7xl mx-auto w-full">
-      <ErrorBoundary>
-        <Outlet />
-      </ErrorBoundary>
-    </div>
-  </main>
-);
+// ErrorBoundary is keyed by route so a crash on one page resets when you
+// navigate away instead of bricking every tab.
+const StandardLayout: React.FC = () => {
+  const location = useLocation();
+  return (
+    <main className="flex-grow min-h-0 overflow-y-auto">
+      <div className="p-4 md:p-6 max-w-7xl mx-auto w-full">
+        <ErrorBoundary key={location.pathname}>
+          <Outlet />
+        </ErrorBoundary>
+      </div>
+    </main>
+  );
+};
 
 // Full-bleed chrome for immersive views (the PDF study page): the page owns
 // the whole area below the header, with no padding or width cap
-const FullBleedLayout: React.FC = () => (
-  <main className="flex-grow w-full min-h-0 flex flex-col overflow-hidden">
-    <ErrorBoundary>
-      <Outlet />
-    </ErrorBoundary>
-  </main>
-);
+const FullBleedLayout: React.FC = () => {
+  const location = useLocation();
+  return (
+    <main className="flex-grow w-full min-h-0 flex flex-col overflow-hidden">
+      <ErrorBoundary key={location.pathname}>
+        <Outlet />
+      </ErrorBoundary>
+    </main>
+  );
+};
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);

--- a/frontend/src/features/user/ProfilePage.tsx
+++ b/frontend/src/features/user/ProfilePage.tsx
@@ -5,6 +5,7 @@ import UserStatsCard from './components/UserStatsCard';
 import BadgeGrid from './components/BadgeGrid';
 import ActivityLog from './components/ActivityLog';
 import { UserBadge } from './userTypes';
+import { flattenUserBadges } from './badgeUtils';
 
 // Simple Analytics Card sub-component
 interface AnalyticsItemProps {
@@ -171,9 +172,7 @@ const ProfilePage: React.FC = () => {
               </button>
             </div>
             { profile &&
-              <BadgeGrid badges={[
-                ...(profile.badges || []),
-              ]} />
+              <BadgeGrid badges={flattenUserBadges(profile.badges)} />
             }
           </div>
           )}

--- a/frontend/src/features/user/badgeUtils.ts
+++ b/frontend/src/features/user/badgeUtils.ts
@@ -1,0 +1,53 @@
+import { UserBadge } from './userTypes';
+
+// The API stores earned badges as nested records:
+//   { _id, badge: { _id, name, description, icon, rarity, category, xpReward }, earnedAt }
+// while the UI components want a flat UserBadge. The Badge model has RARITY
+// (common..legendary), not the UI's level (bronze..platinum), so map it here.
+const rarityToLevel: Record<string, UserBadge['level']> = {
+  common: 'bronze',
+  uncommon: 'silver',
+  rare: 'gold',
+  epic: 'platinum',
+  legendary: 'platinum'
+};
+
+interface RawUserBadgeRecord {
+  _id?: string;
+  badge?: {
+    _id?: string;
+    name?: string;
+    description?: string;
+    icon?: string;
+    rarity?: string;
+    category?: string;
+    xpReward?: number;
+  } | null;
+  earnedAt?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Flatten nested earned-badge records into the UI's UserBadge shape.
+ * Records whose Badge document is missing (deleted badge) are dropped.
+ */
+export const flattenUserBadges = (records: unknown[] | undefined | null): UserBadge[] => {
+  if (!Array.isArray(records)) return [];
+  return records.flatMap((raw) => {
+    const record = raw as RawUserBadgeRecord;
+    // Already-flat objects (some endpoints may pre-flatten) pass through
+    const source = record.badge ?? (record.name ? record : null);
+    if (!source || !source.name) return [];
+    return [{
+      _id: String(source._id ?? record._id ?? source.name),
+      name: source.name,
+      description: source.description ?? '',
+      icon: source.icon ?? '🏅',
+      level: rarityToLevel[String(source.rarity ?? '').toLowerCase()] ?? 'bronze',
+      rarity: source.rarity,
+      category: source.category ?? 'achievement',
+      xpReward: Number(source.xpReward ?? 0),
+      earnedAt: String(record.earnedAt ?? new Date().toISOString())
+    }];
+  });
+};

--- a/frontend/src/features/user/components/BadgeGrid.tsx
+++ b/frontend/src/features/user/components/BadgeGrid.tsx
@@ -26,7 +26,7 @@ const BadgeGrid: React.FC<BadgeGridProps> = ({ badges, newBadgeIds = [], showToa
   useEffect(() => {
     // Show toast notifications for new badges
     newBadgeIds.forEach(badgeId => {
-        const badge = badges.find(b => b.id === badgeId);
+        const badge = badges.find(b => b._id === badgeId);
         if (badge) {
         showToastFn({
             title: 'New Badge Unlocked!',
@@ -96,48 +96,57 @@ const BadgeGrid: React.FC<BadgeGridProps> = ({ badges, newBadgeIds = [], showToa
          </div>
       ) : (
         <div data-testid="badge-grid" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredBadges.map((badge) => (
+          {filteredBadges.map((badge) => {
+            const badgeId = badge._id;
+            const level = badge.level && badge.level in levelColorMap ? badge.level : 'bronze';
+            return (
             <motion.div
-              key={badge.id}
-              data-testid={`badge-item-${badge.id}`}
-              data-badge-level={badge.level}
+              key={badgeId}
+              data-testid={`badge-item-${badgeId}`}
+              data-badge-level={level}
               data-badge-category={badge.category}
-              data-badge-highlighted={highlightedBadges.has(badge.id)}
+              data-badge-highlighted={highlightedBadges.has(badgeId)}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
-              className={`relative p-4 rounded-lg border-2 ${levelColorMap[badge.level]} 
-                ${highlightedBadges.has(badge.id) ? 'ring-2 ring-yellow-400' : ''}`}
+              className={`relative p-4 rounded-lg border-2 ${levelColorMap[level]} 
+                ${highlightedBadges.has(badgeId) ? 'ring-2 ring-yellow-400' : ''}`}
             >
-              {highlightedBadges.has(badge.id) && (
+              {highlightedBadges.has(badgeId) && (
                 <span
-                  data-testid={`badge-new-tag-${badge.id}`}
+                  data-testid={`badge-new-tag-${badgeId}`}
                   className="absolute top-2 right-2 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded"
                 >
                   New!
                 </span>
               )}
               <div className="flex items-center gap-3">
-                <img
-                  src={badge.icon}
-                  alt={badge.name}
-                  className="w-12 h-12 object-contain"
-                />
+                {/* icon may be a URL or an emoji string */}
+                {badge.icon && /^https?:\/\//.test(badge.icon) ? (
+                  <img src={badge.icon} alt={badge.name} className="w-12 h-12 object-contain" />
+                ) : (
+                  <span className="w-12 h-12 flex items-center justify-center text-3xl" aria-hidden="true">
+                    {badge.icon || '🏅'}
+                  </span>
+                )}
                 <div>
                   <h3 className="font-semibold">{badge.name}</h3>
                   <p className="text-sm text-gray-600">{badge.description}</p>
                   <div className="flex items-center gap-2 mt-1">
-                    <span data-testid={`badge-level-${badge.id}`} className="text-xs font-medium">
-                      {badge.level.charAt(0).toUpperCase() + badge.level.slice(1)}
+                    <span data-testid={`badge-level-${badgeId}`} className="text-xs font-medium">
+                      {level.charAt(0).toUpperCase() + level.slice(1)}
                     </span>
-                    <span className="text-xs text-green-600">+{badge.xpReward} XP</span>
+                    <span className="text-xs text-green-600">+{badge.xpReward ?? 0} XP</span>
                   </div>
-                  <p className="text-xs text-gray-500 mt-1">
-                    Earned {new Date(badge.earnedAt).toLocaleDateString()}
-                  </p>
+                  {badge.earnedAt && !Number.isNaN(new Date(badge.earnedAt).getTime()) && (
+                    <p className="text-xs text-gray-500 mt-1">
+                      Earned {new Date(badge.earnedAt).toLocaleDateString()}
+                    </p>
+                  )}
                 </div>
               </div>
             </motion.div>
-          ))}
+            );
+          })}
       </div>
       )}
     </div>

--- a/frontend/src/features/user/userTypes.ts
+++ b/frontend/src/features/user/userTypes.ts
@@ -3,8 +3,11 @@ export interface UserBadge {
   name: string;
   description: string;
   icon: string;
+  /** UI tier derived from the backend's rarity */
   level: 'bronze' | 'silver' | 'gold' | 'platinum';
-  category: 'upload' | 'ai' | 'streak' | 'achievement';
+  /** Original backend rarity (common..legendary), kept for galleries/filters */
+  rarity?: string;
+  category: string;
   xpReward: number;
   earnedAt: string;
 }

--- a/frontend/src/hooks/useBadges.ts
+++ b/frontend/src/hooks/useBadges.ts
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuthContext } from '../features/auth/AuthContext';
+import { flattenUserBadges } from '../features/user/badgeUtils';
 import { callAuthenticatedApi } from '../api/notes';
 import type { ApiResponse } from '../api/notes';
 import { toast } from 'react-hot-toast';
@@ -48,9 +49,12 @@ export const useBadges = () => {
       );
 
       if (response.success && Array.isArray(response.data)) {
-        setEarnedBadges(response.data);
+        // The endpoint returns nested { badge: {...}, earnedAt } records;
+        // flatten them so consumers can read name/rarity/etc. directly.
+        const flat = flattenUserBadges(response.data);
+        setEarnedBadges(flat as unknown as Badge[]);
         setUnearnedBadges([]); // No unearned badges from this endpoint
-        debug(`[useBadges] Fetched ${response.data.length} earned badges.`);
+        debug(`[useBadges] Fetched ${flat.length} earned badges.`);
       } else {
         throw new Error(response.error || response.message || 'Failed to fetch badges: API error');
       }


### PR DESCRIPTION
## What broke
Earning your first badges exposed two stacked bugs:

1. **The crash:** `BadgeGrid` renders `profile.badges`, but the profile stores them as **nested** records (`{ badge: {...}, earnedAt }`) and the backend populate selected only `name/description/icon/rarity` — no `level`, `category`, or `xpReward`. `badge.level.charAt(0)` on `undefined` threw. Deeper: the Badge model **never had a `level` field** — the UI's bronze→platinum tiers were written against an API that doesn't exist.
2. **The brick:** the layout-level `ErrorBoundary` keeps its error state across route changes, so one crashed page took down **every tab** until a full reload (exactly the reported behavior).

## Fixes
- New shared `flattenUserBadges` adapter: nested record → flat UI badge, deriving `level` from the backend's `rarity` (common→bronze … legendary→platinum), with safe fallbacks and dropped records when a Badge doc is missing. Used by ProfilePage **and** `useBadges` — which also fixes `BadgeGallery` silently rendering blank cards off the same nested shape.
- `BadgeGrid` hardened: level/xpReward/earnedAt fallbacks, emoji-vs-URL icon handling, and `badge.id` → `badge._id` (the field that actually exists — keys and "New!" highlights were broken too).
- **ErrorBoundaries are keyed by `location.pathname`** — a crash on one page now resets on navigation instead of bricking the app.
- Backend: profile badge population now includes `category` and `xpReward`.

## Verification
Frontend build + 14/14 tests green; backend tsc clean; CI runs the full suites.

https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZPGzMktQHBMqSwb7246G)_